### PR TITLE
Loading an association implicitly via a `through`

### DIFF
--- a/spec/unit/query/preload/through-associations.spec.ts
+++ b/spec/unit/query/preload/through-associations.spec.ts
@@ -39,6 +39,23 @@ describe('Query#preload through with simple associations', () => {
     })
   })
 
+  context('combined explicit and implicit on the same HasMany through', () => {
+    it('sets HasMany property on the model and BelongsToProperty on the associated model', async () => {
+      const balloon = await Latex.create()
+      const balloonSpotter = await BalloonSpotter.create()
+      const user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+      const balloonSpotterBalloon = await BalloonSpotterBalloon.create({ balloonSpotter, balloon, user })
+
+      const reloaded = await new Query(BalloonSpotter)
+        .preload('balloonSpotterBalloons', 'user')
+        .preload('balloons')
+        .first()
+      expect(reloaded!.balloons).toMatchDreamModels([balloon])
+      expect(reloaded!.balloonSpotterBalloons).toMatchDreamModels([balloonSpotterBalloon])
+      expect(reloaded!.balloonSpotterBalloons[0].user).toMatchDreamModel(user)
+    })
+  })
+
   context('HasOne through HasOne association', () => {
     it(
       'sets the association property and the association property on the through association to the ' +

--- a/test-app/app/models/BalloonSpotterBalloon.ts
+++ b/test-app/app/models/BalloonSpotterBalloon.ts
@@ -5,6 +5,7 @@ import BalloonSpotterBalloonSerializer from '../../../test-app/app/serializers/B
 import BalloonSpotter from './BalloonSpotter'
 import Balloon from './Balloon'
 import ApplicationModel from './ApplicationModel'
+import User from './User'
 
 export default class BalloonSpotterBalloon extends ApplicationModel {
   public get table() {
@@ -18,6 +19,10 @@ export default class BalloonSpotterBalloon extends ApplicationModel {
   public id: IdType
   public createdAt: DateTime
   public updatedAt: DateTime
+
+  @BelongsTo(() => User, { optional: true })
+  public user: User
+  public userId: IdType
 
   @BelongsTo(() => BalloonSpotter)
   public balloonSpotter: BalloonSpotter

--- a/test-app/db/associations.ts
+++ b/test-app/db/associations.ts
@@ -5,6 +5,9 @@ export default {
     ]
   },
   "balloon_spotter_balloons": {
+    "user": [
+      "users"
+    ],
     "balloonSpotter": [
       "balloon_spotters"
     ],
@@ -229,6 +232,9 @@ export interface SyncedAssociations {
     ]
   },
   "balloon_spotter_balloons": {
+    "user": [
+      "users"
+    ],
     "balloonSpotter": [
       "balloon_spotters"
     ],
@@ -453,6 +459,9 @@ export interface SyncedBelongsToAssociations {
     ]
   },
   "balloon_spotter_balloons": {
+    "user": [
+      "users"
+    ],
     "balloonSpotter": [
       "balloon_spotters"
     ],

--- a/test-app/db/migrations/1689881646230-create-balloon-spotter-balloons.ts
+++ b/test-app/db/migrations/1689881646230-create-balloon-spotter-balloons.ts
@@ -4,6 +4,7 @@ export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .createTable('balloon_spotter_balloons')
     .addColumn('id', 'bigserial', col => col.primaryKey())
+    .addColumn('user_id', 'bigint', col => col.references('users.id').onDelete('cascade'))
     .addColumn('balloon_spotter_id', 'bigint', col =>
       col.references('balloon_spotters.id').onDelete('cascade').notNull()
     )

--- a/test-app/db/schema.ts
+++ b/test-app/db/schema.ts
@@ -35,6 +35,7 @@ export interface BalloonLines {
 
 export interface BalloonSpotterBalloons {
   id: Generated<Int8>;
+  userId: Int8 | null;
   balloonSpotterId: Int8;
   balloonId: Int8;
   createdAt: Timestamp;
@@ -242,7 +243,7 @@ export interface DB {
 
 
 export const BalloonLineColumns = ['id', 'balloonId', 'material', 'createdAt', 'updatedAt']
-export const BalloonSpotterBalloonColumns = ['id', 'balloonSpotterId', 'balloonId', 'createdAt', 'updatedAt']
+export const BalloonSpotterBalloonColumns = ['id', 'userId', 'balloonSpotterId', 'balloonId', 'createdAt', 'updatedAt']
 export const BalloonSpotterColumns = ['id', 'name', 'createdAt', 'updatedAt']
 export const BeautifulBalloonColumns = ['id', 'userId', 'type', 'volume', 'color', 'positionAlpha', 'positionBeta', 'multicolor', 'deletedAt', 'createdAt', 'updatedAt']
 export const CollarColumns = ['id', 'petId', 'lost', 'createdAt', 'updatedAt']
@@ -273,6 +274,7 @@ export interface BalloonLineAttributes {
 
 export interface BalloonSpotterBalloonAttributes {
   id: IdType
+  userId: IdType | null
   balloonSpotterId: IdType
   balloonId: IdType
   createdAt: DateTime
@@ -465,6 +467,7 @@ export const BalloonLinesDBTypeMap = {
 
 export const BalloonSpotterBalloonsDBTypeMap = {
   id: 'bigint',
+  userId: 'bigint',
   balloonSpotterId: 'bigint',
   balloonId: 'bigint',
   createdAt: 'timestamp without time zone',


### PR DESCRIPTION
association when that association had already
been loaded explicitly was resetting the associated object, causing any subsequent preloads on that
object to be lost, resulting in `NonLoadedAssociation` exceptions when accessing associations that
should have been preloaded