### PR TITLE
Deep clone to prevent external modification of the ops

### DIFF
--- a/spec/unit/query/joins/simple-associations.spec.ts
+++ b/spec/unit/query/joins/simple-associations.spec.ts
@@ -8,6 +8,7 @@ import Query from '../../../../src/dream/query'
 import Mylar from '../../../../test-app/app/models/Balloon/Mylar'
 import Balloon from '../../../../test-app/app/models/Balloon'
 import ops from '../../../../src/ops'
+import OpsStatement from '../../../../src/ops/ops-statement'
 
 describe('Query#joins with simple associations', () => {
   it('joins a HasOne association', async () => {
@@ -83,6 +84,21 @@ describe('Query#joins with simple associations', () => {
 
         const balloons = await Balloon.joins('user', { name: ops.similarity('hello') }).all()
         expect(balloons).toMatchDreamModels([balloon1, balloon2])
+      })
+    })
+
+    context('with an ops object', () => {
+      it('changing the ops object after joining does not affect the join', async () => {
+        const user1 = await User.create({ email: 'fred@frewd', password: 'howyadoin', name: 'Hello World' })
+        const user2 = await User.create({ email: 'how@yadoin', password: 'howyadoin', name: 'Hallo' })
+        const balloon1 = await Mylar.create({ user: user1 })
+        const balloon2 = await Mylar.create({ user: user2 })
+
+        const whereClause: Record<string, OpsStatement<any, any>> = { id: ops.equal(user1.id) }
+        const query = Balloon.joins('user', whereClause)
+        whereClause.id.value = user2.id
+        const balloons = await query.all()
+        expect(balloons).toMatchDreamModels([balloon1])
       })
     })
 

--- a/src/dream/query.ts
+++ b/src/dream/query.ts
@@ -62,6 +62,7 @@ import SimilarityBuilder from './internal/similarity/SimilarityBuilder'
 import ConnectedToDB from '../db/ConnectedToDB'
 import SimilarityOperatorNotSupportedOnDestroyQueries from '../exceptions/similarity-operator-not-supported-on-destroy-queries'
 import debug from '../../shared/helpers/debug'
+import cloneDeep from 'lodash.clonedeep'
 
 const OPERATION_NEGATION_MAP: Partial<{ [Property in ComparisonOperator]: ComparisonOperator }> = {
   '=': '!=',
@@ -295,9 +296,12 @@ export default class Query<
         associationStatements
       )
     } else if (isObject(nextAssociationStatement) && previousAssociationName) {
-      Object.keys(nextAssociationStatement).forEach((key: string) => {
-        joinsWhereStatements[key] = (nextAssociationStatement as any)[key]
+      const clonedNextAssociationStatement = cloneDeep(nextAssociationStatement)
+
+      Object.keys(clonedNextAssociationStatement).forEach((key: string) => {
+        joinsWhereStatements[key] = (clonedNextAssociationStatement as any)[key]
       })
+
       this.fleshOutJoinsStatements(
         joinsStatements,
         joinsWhereStatements,
@@ -388,8 +392,10 @@ export default class Query<
         associationStatements
       )
     } else if (isObject(nextAssociationStatement) && previousAssociationName) {
-      Object.keys(nextAssociationStatement).forEach((key: string) => {
-        joinsWhereStatements[key] = (nextAssociationStatement as any)[key]
+      const clonedNextAssociationStatement = cloneDeep(nextAssociationStatement)
+
+      Object.keys(clonedNextAssociationStatement).forEach((key: string) => {
+        joinsWhereStatements[key] = (clonedNextAssociationStatement as any)[key]
       })
 
       return this.fleshOutJoinsPluckStatements(


### PR DESCRIPTION
statement from affecting a query after generating that query but before executing it. This problem was discovered in a real use case in which a base query was stored in a variable and then used to generate subsequent
queries before any of them were executed, but the changes introduced into the subsequent queries altered the original query.

fleshOutJoinsPluckStatements updated for symmetry, but no spec because, since it's executed immediately as part of the call, there's no way to alter the passed object before the passed object is translated into a Kysely query and sent to the database