### PR TITLE
Fix updateable association types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/src/decorators/associations/shared.ts
+++ b/src/decorators/associations/shared.ts
@@ -16,15 +16,19 @@ import camelize from '../../../shared/helpers/camelize'
 import NonLoadedAssociation from '../../exceptions/associations/non-loaded-association'
 import associationToGetterSetterProp from './associationToGetterSetterProp'
 
+type AssociatedModelType<
+  I extends Dream,
+  AssociationName extends keyof I['dreamconf']['syncedBelongsToAssociations'][I['table'] &
+    keyof I['dreamconf']['syncedBelongsToAssociations']],
+  PossibleArrayAssociationType = I[AssociationName & keyof I]
+> = PossibleArrayAssociationType extends (infer ElementType)[] ? ElementType : PossibleArrayAssociationType
+
 export type AssociatedModelParam<
   I extends Dream,
   AssociationName = keyof I['dreamconf']['syncedBelongsToAssociations'][I['table'] &
-    keyof I['dreamconf']['syncedBelongsToAssociations']],
-  PossibleArrayAssociationType = I[AssociationName & keyof I],
-  AssociationType = PossibleArrayAssociationType extends (infer ElementType)[]
-    ? ElementType
-    : PossibleArrayAssociationType
-> = Partial<Record<AssociationName & string, AssociationType | null>>
+    keyof I['dreamconf']['syncedBelongsToAssociations']] &
+    string
+> = Partial<{ [K in AssociationName & string]: AssociatedModelType<I, K> | null }>
 
 export type PassthroughWhere<AllColumns extends string[]> = Partial<Record<AllColumns[number], any>>
 


### PR DESCRIPTION
Example:
await EdgeNode.create({edge, node: node1})
before fix, hovering over `edge` gave: (property) edge?: Node | Edge | null | undefined after fix, hovering over `edge` gives: (property) edge?: Edge | undefined

Addresses https://rvohealth.atlassian.net/browse/PDTC-3918