### PR TITLE
Use Set instead of Array for O(1) checking of column presence

### DIFF
--- a/boot/sync.ts
+++ b/boot/sync.ts
@@ -201,7 +201,7 @@ function indexInterfaceKeys(str: string) {
 
   const keys = tableInterfaceToColumns(str)
 
-  return `export const ${pluralize.singular(name)}Columns = [${keys.join(', ')}] as const`
+  return `export const ${pluralize.singular(name)}Columns = new Set([${keys.join(', ')}])`
 }
 
 function allColumns(tableInterfaces: string[]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/src/decorators/sortable/helpers/getColumnForSortableScope.ts
+++ b/src/decorators/sortable/helpers/getColumnForSortableScope.ts
@@ -10,7 +10,7 @@ export default function getColumnForSortableScope(dream: Dream, scope?: string) 
 
   const dreamClass = dream.constructor as typeof Dream
 
-  if (dreamClass.columns().includes(scope)) return scope
+  if (dreamClass.columns().has(scope)) return scope
 
   const associationMetadata = (dream.associationMap() as any)[scope] as
     | BelongsToStatement<any, any, string>

--- a/src/dream.ts
+++ b/src/dream.ts
@@ -165,7 +165,7 @@ export default class Dream {
     DB extends I['DB'],
     TableName extends keyof DB = InstanceType<T>['table'] & keyof DB,
     Table extends DB[keyof DB] = DB[TableName]
-  >(): (keyof Table & string)[] {
+  >(): Set<keyof Table & string> {
     return (this.prototype.dreamconf.dbColumns as any)[this.prototype.table]
   }
 
@@ -1162,7 +1162,7 @@ export default class Dream {
     const columns = (this.constructor as typeof Dream).columns()
     const self = this as any
 
-    if (columns.includes(attr)) {
+    if (columns.has(attr)) {
       self.currentAttributes[attr] = isJsonColumn(this.constructor as typeof Dream, attr)
         ? isString(val)
           ? val
@@ -1177,7 +1177,7 @@ export default class Dream {
     const columns = (this.constructor as typeof Dream).columns()
     const self = this as any
 
-    if (columns.includes(attr)) {
+    if (columns.has(attr)) {
       return self.currentAttributes[attr]
     } else {
       return self[attr]
@@ -1279,7 +1279,7 @@ export default class Dream {
     DB extends I['DB'],
     TableName extends keyof DB = I['table'] & keyof DB,
     Table extends DB[keyof DB] = DB[TableName]
-  >(this: I): (keyof Table)[] {
+  >(this: I): Set<keyof Table> {
     return (this.constructor as DreamConstructorType<I>).columns()
   }
 

--- a/src/dream/internal/saveDream.ts
+++ b/src/dream/internal/saveDream.ts
@@ -32,9 +32,9 @@ export default async function saveDream<DreamInstance extends Dream>(
   let query: any
 
   const now = DateTime.now()
-  if (!alreadyPersisted && !(dream as any).createdAt && (dream.columns() as any[]).includes('createdAt'))
+  if (!alreadyPersisted && !(dream as any).createdAt && dream.columns().has('createdAt'))
     (dream as any).createdAt = now
-  if (!(dream.dirtyAttributes() as any).updatedAt && (dream.columns() as any[]).includes('updatedAt'))
+  if (!(dream.dirtyAttributes() as any).updatedAt && dream.columns().has('updatedAt'))
     (dream as any).updatedAt = now
 
   const sqlifiedAttributes = sqlAttributes(dream)
@@ -52,7 +52,7 @@ export default async function saveDream<DreamInstance extends Dream>(
   // BeforeSave/Update actions may clear all the data that we intended to save, leaving us with
   // an invalid update command. The Sortable decorator is an example of this.
   if (!alreadyPersisted || Object.keys(sqlifiedAttributes).length) {
-    const data = await executeDatabaseQuery(query.returning(dream.columns()), 'executeTakeFirstOrThrow')
+    const data = await executeDatabaseQuery(query.returning([...dream.columns()]), 'executeTakeFirstOrThrow')
     dream.setAttributes(data)
   }
 

--- a/src/dream/query.ts
+++ b/src/dream/query.ts
@@ -1277,12 +1277,12 @@ export default class Query<
     if ((association.polymorphic && association.type === 'BelongsTo') || Array.isArray(dreamClassToHydrate))
       return this.preloadPolymorphicBelongsTo(association as BelongsToStatement<any, any, string>, dreams)
 
-    const dreamClassToHydrateColumns = dreamClassToHydrate.columns()
+    const dreamClassToHydrateColumns = [...dreamClassToHydrate.columns()]
     const throughColumnsToHydrate: any[] = []
 
-    const columnsToPluck = [
-      ...(dreamClassToHydrateColumns.map(column => `${associationName}.${column.toString()}`) as any[]),
-    ]
+    const columnsToPluck = dreamClassToHydrateColumns.map(
+      column => `${associationName}.${column.toString()}`
+    ) as any[]
 
     const asHasAssociation = association as HasManyStatement<any, any, any> | HasOneStatement<any, any, any>
 

--- a/src/exceptions/associations/explicit-foreign-key.ts
+++ b/src/exceptions/associations/explicit-foreign-key.ts
@@ -69,8 +69,7 @@ export function checkForeignKey(
   if (partialAssociation.type === 'BelongsTo') table = dreamClass.prototype.table
   else table = modelCBtoSingleDreamClass(dreamClass, partialAssociation).prototype.table
 
-  const validForeignKey =
-    (dreamClass.prototype.dreamconf.dbColumns as any)[table].indexOf(computedForeignKey) > -1
+  const validForeignKey = (dreamClass.prototype.dreamconf.dbColumns as any)[table].has(computedForeignKey)
   if (validForeignKey) return
 
   if (explicitForeignKey)

--- a/src/exceptions/sortable-decorator-requires-column-or-belongs-to-association.ts
+++ b/src/exceptions/sortable-decorator-requires-column-or-belongs-to-association.ts
@@ -18,7 +18,7 @@ received:
   scope: ${this.attributeOrScope}
 
 Columns on ${this.dreamClass.name} are:
-  ${this.dreamClass.columns().join('\n        ')}
+  ${[...this.dreamClass.columns()].join('\n        ')}
 
 BelongsTo scopes on ${this.dreamClass.name} are:
   ${this.dreamClass['associations'].belongsTo.map(assoc => assoc.as).join('\n        ')}

--- a/test-app/db/schema.ts
+++ b/test-app/db/schema.ts
@@ -381,30 +381,30 @@ export interface DB {
 }
 
 
-export const BalloonLineColumns = ['balloonId', 'createdAt', 'id', 'material', 'updatedAt'] as const
-export const BalloonSpotterBalloonColumns = ['balloonId', 'balloonSpotterId', 'createdAt', 'id', 'updatedAt', 'userId'] as const
-export const BalloonSpotterColumns = ['createdAt', 'id', 'name', 'updatedAt'] as const
-export const BeautifulBalloonColumns = ['color', 'createdAt', 'deletedAt', 'id', 'multicolor', 'positionAlpha', 'positionBeta', 'type', 'updatedAt', 'userId', 'volume'] as const
-export const CollarColumns = ['balloonId', 'createdAt', 'id', 'lost', 'petId', 'tagName', 'updatedAt'] as const
-export const CompositionAssetAuditColumns = ['approval', 'compositionAssetId', 'createdAt', 'id', 'notes', 'updatedAt'] as const
-export const CompositionAssetColumns = ['compositionId', 'createdAt', 'id', 'name', 'primary', 'score', 'src', 'updatedAt'] as const
-export const CompositionColumns = ['content', 'createdAt', 'id', 'metadata', 'metadata2', 'metadata3', 'primary', 'updatedAt', 'userId'] as const
-export const EdgeCaseAttributeColumns = ['createdAt', 'id', 'kPop', 'popK', 'popKPop', 'updatedAt'] as const
-export const ExtraRatingColumns = ['body', 'createdAt', 'extraRateableId', 'extraRateableType', 'id', 'rating', 'type', 'updatedAt', 'userId'] as const
-export const GraphEdgeNodeColumns = ['createdAt', 'edgeId', 'id', 'multiScopedPosition', 'nodeId', 'position', 'updatedAt'] as const
-export const GraphEdgeColumns = ['createdAt', 'id', 'name', 'updatedAt', 'weight'] as const
-export const GraphNodeColumns = ['createdAt', 'id', 'name', 'omittedEdgePosition', 'updatedAt'] as const
-export const IncompatibleForeignKeyTypeExampleColumns = ['createdAt', 'id', 'updatedAt', 'userId'] as const
-export const LocalizedTextColumns = ['body', 'createdAt', 'id', 'locale', 'localizableId', 'localizableType', 'name', 'title', 'updatedAt'] as const
-export const ModelWithoutUpdatedAtColumns = ['cantUpdateThis', 'createdAt', 'id', 'name'] as const
-export const PetColumns = ['createdAt', 'deletedAt', 'favoriteTreats', 'id', 'name', 'nickname', 'positionWithinSpecies', 'species', 'userId'] as const
-export const PetUnderstudyJoinModelColumns = ['createdAt', 'id', 'petId', 'understudyId', 'updatedAt'] as const
-export const PostColumns = ['body', 'createdAt', 'deletedAt', 'id', 'position', 'postVisibilityId', 'updatedAt', 'userId'] as const
-export const PostVisibilityColumns = ['createdAt', 'id', 'notes', 'updatedAt', 'visibility'] as const
-export const RatingColumns = ['body', 'createdAt', 'id', 'rateableId', 'rateableType', 'rating', 'updatedAt', 'userId'] as const
-export const SandbagColumns = ['balloonId', 'createdAt', 'id', 'updatedAt', 'weight', 'weightKgs', 'weightTons'] as const
-export const UserColumns = ['birthdate', 'createdAt', 'deletedAt', 'email', 'featuredPostPosition', 'id', 'name', 'passwordDigest', 'socialSecurityNumber', 'targetRating', 'updatedAt'] as const
-export const UserSettingColumns = ['createdAt', 'id', 'likesChalupas', 'updatedAt', 'userId'] as const
+export const BalloonLineColumns = new Set(['balloonId', 'createdAt', 'id', 'material', 'updatedAt'])
+export const BalloonSpotterBalloonColumns = new Set(['balloonId', 'balloonSpotterId', 'createdAt', 'id', 'updatedAt', 'userId'])
+export const BalloonSpotterColumns = new Set(['createdAt', 'id', 'name', 'updatedAt'])
+export const BeautifulBalloonColumns = new Set(['color', 'createdAt', 'deletedAt', 'id', 'multicolor', 'positionAlpha', 'positionBeta', 'type', 'updatedAt', 'userId', 'volume'])
+export const CollarColumns = new Set(['balloonId', 'createdAt', 'id', 'lost', 'petId', 'tagName', 'updatedAt'])
+export const CompositionAssetAuditColumns = new Set(['approval', 'compositionAssetId', 'createdAt', 'id', 'notes', 'updatedAt'])
+export const CompositionAssetColumns = new Set(['compositionId', 'createdAt', 'id', 'name', 'primary', 'score', 'src', 'updatedAt'])
+export const CompositionColumns = new Set(['content', 'createdAt', 'id', 'metadata', 'metadata2', 'metadata3', 'primary', 'updatedAt', 'userId'])
+export const EdgeCaseAttributeColumns = new Set(['createdAt', 'id', 'kPop', 'popK', 'popKPop', 'updatedAt'])
+export const ExtraRatingColumns = new Set(['body', 'createdAt', 'extraRateableId', 'extraRateableType', 'id', 'rating', 'type', 'updatedAt', 'userId'])
+export const GraphEdgeNodeColumns = new Set(['createdAt', 'edgeId', 'id', 'multiScopedPosition', 'nodeId', 'position', 'updatedAt'])
+export const GraphEdgeColumns = new Set(['createdAt', 'id', 'name', 'updatedAt', 'weight'])
+export const GraphNodeColumns = new Set(['createdAt', 'id', 'name', 'omittedEdgePosition', 'updatedAt'])
+export const IncompatibleForeignKeyTypeExampleColumns = new Set(['createdAt', 'id', 'updatedAt', 'userId'])
+export const LocalizedTextColumns = new Set(['body', 'createdAt', 'id', 'locale', 'localizableId', 'localizableType', 'name', 'title', 'updatedAt'])
+export const ModelWithoutUpdatedAtColumns = new Set(['cantUpdateThis', 'createdAt', 'id', 'name'])
+export const PetColumns = new Set(['createdAt', 'deletedAt', 'favoriteTreats', 'id', 'name', 'nickname', 'positionWithinSpecies', 'species', 'userId'])
+export const PetUnderstudyJoinModelColumns = new Set(['createdAt', 'id', 'petId', 'understudyId', 'updatedAt'])
+export const PostColumns = new Set(['body', 'createdAt', 'deletedAt', 'id', 'position', 'postVisibilityId', 'updatedAt', 'userId'])
+export const PostVisibilityColumns = new Set(['createdAt', 'id', 'notes', 'updatedAt', 'visibility'])
+export const RatingColumns = new Set(['body', 'createdAt', 'id', 'rateableId', 'rateableType', 'rating', 'updatedAt', 'userId'])
+export const SandbagColumns = new Set(['balloonId', 'createdAt', 'id', 'updatedAt', 'weight', 'weightKgs', 'weightTons'])
+export const UserColumns = new Set(['birthdate', 'createdAt', 'deletedAt', 'email', 'featuredPostPosition', 'id', 'name', 'passwordDigest', 'socialSecurityNumber', 'targetRating', 'updatedAt'])
+export const UserSettingColumns = new Set(['createdAt', 'id', 'likesChalupas', 'updatedAt', 'userId'])
 
 export const AllColumns = ['approval', 'balloonId', 'balloonLines', 'balloonSpotterBalloons', 'balloonSpotterId', 'balloonSpotters', 'beautifulBalloons', 'birthdate', 'body', 'cantUpdateThis', 'collars', 'color', 'compositionAssetAudits', 'compositionAssetId', 'compositionAssets', 'compositionId', 'compositions', 'content', 'createdAt', 'deletedAt', 'edgeCaseAttributes', 'edgeId', 'email', 'extraRateableId', 'extraRateableType', 'extraRatings', 'favoriteTreats', 'featuredPostPosition', 'graphEdgeNodes', 'graphEdges', 'graphNodes', 'id', 'incompatibleForeignKeyTypeExamples', 'kPop', 'likesChalupas', 'locale', 'localizableId', 'localizableType', 'localizedTexts', 'lost', 'material', 'metadata', 'metadata2', 'metadata3', 'modelWithoutUpdatedAt', 'multiScopedPosition', 'multicolor', 'name', 'nickname', 'nodeId', 'notes', 'omittedEdgePosition', 'passwordDigest', 'petId', 'petUnderstudyJoinModels', 'pets', 'popK', 'popKPop', 'position', 'positionAlpha', 'positionBeta', 'positionWithinSpecies', 'postVisibilities', 'postVisibilityId', 'posts', 'primary', 'rateableId', 'rateableType', 'rating', 'ratings', 'sandbags', 'score', 'socialSecurityNumber', 'species', 'src', 'tagName', 'targetRating', 'title', 'type', 'understudyId', 'updatedAt', 'userId', 'userSettings', 'users', 'visibility', 'volume', 'weight', 'weightKgs', 'weightTons'] as const
 


### PR DESCRIPTION
Although [The specification requires sets to be implemented "that, on average, provide access times that are sublinear on the number of elements in the collection"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), according to https://v8.dev/blog/hash-code: Map, Set, WeakSet, and WeakMap, all use hash tables under the hood

Closes https://rvohealth.atlassian.net/browse/PDTC-4249