### PR TITLE
Only allow alphanumeric and underscore into raw

### DIFF
--- a/src/dream/query.ts
+++ b/src/dream/query.ts
@@ -2221,8 +2221,6 @@ export default class Query<
     })
   }
 
-  // selfAlias and selfWhereClause are hard-coded into the model. They are never
-  // populated with untrusted data, so the use of `sql.raw` is safe.
   private rawifiedSelfWhereClause({
     associationAlias,
     selfAlias,
@@ -2232,8 +2230,11 @@ export default class Query<
     selfAlias: string
     selfWhereClause: WhereSelfStatement<DB, SyncedAssociations, InstanceType<DreamClass>['table']>
   }) {
+    const alphanumericUnderscoreRegexp = /[^a-zA-Z0-9_]/g
+    selfAlias = selfAlias.replaceAll(alphanumericUnderscoreRegexp, '')
+
     return Object.keys(selfWhereClause).reduce((acc, key) => {
-      const selfColumn = selfWhereClause[key]
+      const selfColumn = selfWhereClause[key]?.replaceAll(alphanumericUnderscoreRegexp, '')
       if (!selfColumn) return acc
 
       acc[`${associationAlias}.${key}`] = sql.raw(`"${snakeify(selfAlias)}"."${snakeify(selfColumn)}"`)


### PR DESCRIPTION
Although the comment was correct for any circumstance we foresaw, to avoid the possibility of SQL injection in situations we can't foresee, we ensure that table and column names sent into raw on the left side of a where clause only have alphanumeric and underscore characters.