### PR TITLE
fix various issues with api generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/cli/generateApiSchemaContent.spec.ts
+++ b/spec/unit/cli/generateApiSchemaContent.spec.ts
@@ -70,10 +70,46 @@ export interface GraphNode {
     })
   })
 
+  it('renders valid serializer even when serializer is not exported default', async () => {
+    const file = await generateApiSchemaContent()
+    expect(file).toContain(`\
+export interface PostVisibility {
+  pet: Pet
+  understudy: Pet
+}`)
+  })
+
   context('associations', () => {
     it('ignores invalid associations', async () => {
       const file = await generateApiSchemaContent()
       expect(file).not.toContain('gobbledeegook')
+    })
+
+    it('renders valid associations even when serializers are not exported default', async () => {
+      const file = await generateApiSchemaContent()
+      expect(file).toContain(`\
+export interface Post {
+  postVisibility: PostVisibility
+}`)
+    })
+
+    it('allows passing of serializer path and export to override default path/export expectations', async () => {
+      const file = await generateApiSchemaContent()
+      expect(file).toContain(`\
+export interface Composition {
+  id: any
+  metadata: any
+  localizedTexts: LocalizedTextBase[]
+  currentLocalizedText: LocalizedTextBase
+}`)
+    })
+
+    context('given a serializer which is not exported as default, nor as the name of the file', () => {
+      it('still catalogues serializer, but does not include non-serializers exported from the same file', async () => {
+        const file = await generateApiSchemaContent()
+        expect(file).toContain('export interface LocalizedTextBase')
+        expect(file).not.toContain('thisFunctionShouldNotBePartOfClientApiExport')
+      })
     })
 
     context('RendersOne', () => {

--- a/src/serializer/decorators/associations/renders-many.ts
+++ b/src/serializer/decorators/associations/renders-many.ts
@@ -1,6 +1,5 @@
 import DreamSerializer from '../..'
-import { DreamConst } from '../../../dream/types'
-import { AssociationStatement, DreamSerializerClassCB } from './shared'
+import { AssociationStatement, DreamSerializerClassCB, RendersOneOrManyOpts } from './shared'
 
 export default function RendersMany(
   serializerClassCB: DreamSerializerClassCB | RendersManyOpts | null = null,
@@ -27,13 +26,11 @@ export default function RendersMany(
         serializerClassCB,
         source: opts.source || key,
         through: opts.through || null,
+        path: opts.path || null,
+        exportedAs: opts.exportedAs || null,
       } as AssociationStatement,
     ]
   }
 }
 
-export interface RendersManyOpts {
-  optional?: boolean
-  source?: string | typeof DreamConst.passthrough
-  through?: string
-}
+export interface RendersManyOpts extends RendersOneOrManyOpts {}

--- a/src/serializer/decorators/associations/renders-one.ts
+++ b/src/serializer/decorators/associations/renders-one.ts
@@ -1,6 +1,5 @@
 import DreamSerializer from '../..'
-import { DreamConst } from '../../../dream/types'
-import { AssociationStatement, DreamSerializerClassCB } from './shared'
+import { AssociationStatement, DreamSerializerClassCB, RendersOneOrManyOpts } from './shared'
 
 export default function RendersOne(
   serializerClassCB: DreamSerializerClassCB | RendersOneOpts | null = null,
@@ -28,14 +27,13 @@ export default function RendersOne(
         serializerClassCB,
         source: opts.source || key,
         through: opts.through || null,
+        path: opts.path || null,
+        exportedAs: opts.exportedAs || null,
       } as AssociationStatement,
     ]
   }
 }
 
-export interface RendersOneOpts {
+export interface RendersOneOpts extends RendersOneOrManyOpts {
   flatten?: boolean
-  optional?: boolean
-  source?: string | typeof DreamConst.passthrough
-  through?: string
 }

--- a/src/serializer/decorators/associations/shared.ts
+++ b/src/serializer/decorators/associations/shared.ts
@@ -13,4 +13,14 @@ export interface AssociationStatement {
   source: string | typeof DreamConst.passthrough
   through: string | null
   type: SerializableAssociationType
+  path: string | null
+  exportedAs: string | null
+}
+
+export interface RendersOneOrManyOpts {
+  optional?: boolean
+  source?: string | typeof DreamConst.passthrough
+  through?: string
+  path?: string
+  exportedAs?: string
 }

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -14,8 +14,12 @@ import FailedToRenderThroughAssociationForSerializer from '../exceptions/seriali
 export default class DreamSerializer<DataType = any, PassthroughDataType = any> {
   public static attributeStatements: AttributeStatement[] = []
   public static associationStatements: AssociationStatement[] = []
+  public static readonly isDreamSerializer = true
+
   private _data: DataType
   private _casing: 'snake' | 'camel' | null = null
+  public readonly isDreamSerializerInstance = true
+
   constructor(data: DataType) {
     this._data = data
 

--- a/test-app/app/models/Composition.ts
+++ b/test-app/app/models/Composition.ts
@@ -16,10 +16,15 @@ import User from './User'
 import HeartRating from './ExtraRating/HeartRating'
 import ApplicationModel from './ApplicationModel'
 import LocalizedText from './LocalizedText'
+import CompositionSerializer from '../serializers/CompositionSerializer'
 
 export default class Composition extends ApplicationModel {
   public get table() {
     return 'compositions' as const
+  }
+
+  public get serializer() {
+    return CompositionSerializer
   }
 
   public id: IdType

--- a/test-app/app/models/LocalizedText.ts
+++ b/test-app/app/models/LocalizedText.ts
@@ -5,10 +5,15 @@ import { IdType } from '../../../src/dream/types'
 import Composition from './Composition'
 import CompositionAsset from './CompositionAsset'
 import { LocalesEnum, LocalizableTypesEnum } from '../../db/schema'
+import { LocalizedTextBaseSerializer } from '../serializers/LocalizedText/BaseSerializer'
 
 export default class LocalizedText extends ApplicationModel {
   public get table() {
     return 'localized_texts' as const
+  }
+
+  public get serializer() {
+    return LocalizedTextBaseSerializer<any>
   }
 
   public id: IdType

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -10,10 +10,15 @@ import User from './User'
 import HeartRating from './ExtraRating/HeartRating'
 import ApplicationModel from './ApplicationModel'
 import Sortable from '../../../src/decorators/sortable'
+import PostSerializer from '../serializers/PostSerializer'
 
 export default class Post extends ApplicationModel {
   public get table() {
     return 'posts' as const
+  }
+
+  public get serializer() {
+    return PostSerializer<any>
   }
 
   public id: IdType

--- a/test-app/app/models/PostVisibility.ts
+++ b/test-app/app/models/PostVisibility.ts
@@ -4,10 +4,15 @@ import HasOne from '../../../src/decorators/associations/has-one'
 import { IdType } from '../../../src/dream/types'
 import Post from './Post'
 import ApplicationModel from './ApplicationModel'
+import { PostVisibilitySerializer } from '../serializers/PostVisibilitySerializer'
 
 export default class PostVisibility extends ApplicationModel {
   public get table() {
     return 'post_visibilities' as const
+  }
+
+  public get serializer() {
+    return PostVisibilitySerializer<any>
   }
 
   public id: IdType

--- a/test-app/app/serializers/CompositionSerializer.ts
+++ b/test-app/app/serializers/CompositionSerializer.ts
@@ -1,6 +1,9 @@
+import { RendersMany, RendersOne } from '../../../src'
 import DreamSerializer from '../../../src/serializer'
 import Attribute from '../../../src/serializer/decorators/attribute'
 import { CompositionMetadata } from '../models/Composition'
+import LocalizedText from '../models/LocalizedText'
+import { LocalizedTextBaseSerializer } from './LocalizedText/BaseSerializer'
 
 export default class CompositionSerializer extends DreamSerializer {
   @Attribute()
@@ -8,4 +11,16 @@ export default class CompositionSerializer extends DreamSerializer {
 
   @Attribute('json')
   public metadata: CompositionMetadata
+
+  @RendersMany(() => LocalizedTextBaseSerializer<any>, {
+    path: 'LocalizedText/BaseSerializer',
+    exportedAs: 'LocalizedTextBaseSerializer',
+  })
+  public localizedTexts: LocalizedText[]
+
+  @RendersOne(() => LocalizedTextBaseSerializer<any>, {
+    path: 'LocalizedText/BaseSerializer',
+    exportedAs: 'LocalizedTextBaseSerializer',
+  })
+  public currentLocalizedText: LocalizedText
 }

--- a/test-app/app/serializers/LocalizedText/BaseSerializer.ts
+++ b/test-app/app/serializers/LocalizedText/BaseSerializer.ts
@@ -1,0 +1,6 @@
+import DreamSerializer from '../../../../src/serializer'
+import LocalizedText from '../../models/LocalizedText'
+
+export class LocalizedTextBaseSerializer<DataType extends LocalizedText> extends DreamSerializer<DataType> {}
+
+export function thisFunctionShouldNotBePartOfClientApiExport() {}

--- a/test-app/app/serializers/PostSerializer.ts
+++ b/test-app/app/serializers/PostSerializer.ts
@@ -1,0 +1,9 @@
+import RendersOne from '../../../src/serializer/decorators/associations/renders-one'
+import DreamSerializer from '../../../src/serializer'
+import PostVisibility from '../models/PostVisibility'
+import Post from '../models/Post'
+
+export default class PostSerializer<DataType extends Post> extends DreamSerializer<DataType> {
+  @RendersOne()
+  public postVisibility: PostVisibility
+}

--- a/test-app/app/serializers/PostVisibilitySerializer.ts
+++ b/test-app/app/serializers/PostVisibilitySerializer.ts
@@ -1,0 +1,16 @@
+import RendersOne from '../../../src/serializer/decorators/associations/renders-one'
+import DreamSerializer from '../../../src/serializer'
+import Pet from '../models/Pet'
+import PostVisibility from '../models/PostVisibility'
+import PetSerializer from './PetSerializer'
+
+// NOTE: this serializer is intentionally exported
+// non-default to test that our client api
+// generator can support it
+export class PostVisibilitySerializer<DataType extends PostVisibility> extends DreamSerializer<DataType> {
+  @RendersOne(() => PetSerializer)
+  public pet: Pet
+
+  @RendersOne(() => PetSerializer)
+  public understudy: Pet
+}

--- a/test-app/client/schema.ts
+++ b/test-app/client/schema.ts
@@ -114,6 +114,8 @@ export interface Collar {
 export interface Composition {
   id: any
   metadata: any
+  localizedTexts: LocalizedTextBase[]
+  currentLocalizedText: LocalizedTextBase
 }
 
 export interface EdgeCaseAttribute {
@@ -136,6 +138,9 @@ export interface GraphNode {
   name: any
 }
 
+export interface LocalizedTextBase {
+}
+
 export interface Pet {
   id: string
   name: string
@@ -144,6 +149,15 @@ export interface Pet {
 }
 
 export interface PetUnderstudyJoinModel {
+  pet: Pet
+  understudy: Pet
+}
+
+export interface Post {
+  postVisibility: PostVisibility
+}
+
+export interface PostVisibility {
   pet: Pet
   understudy: Pet
 }


### PR DESCRIPTION
* ensure that all serializers in a serializer file are loaded
* ignore anything in a serializer file that isn't a serializer
* add api for RendersOne, RendersMany to include path and exportAs options, which customize the import logic when generating the client api schema
* bail when a serializer cannot be found

close https://rvohealth.atlassian.net/browse/PDTC-4821