### PR TITLE
Prevent an already used namespace from being suggested

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/joins.spec.ts
+++ b/spec/unit/dream/joins.spec.ts
@@ -24,21 +24,5 @@ describe('Dream.joins', () => {
         expect(reloadedUsers).toMatchDreamModels([user])
       })
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await ApplicationModel.transaction(txn => {
-        User.txn(txn).joins('pets', 'collars', 'pet', 'collars', 'pet', 'collars', 'pet')
-      })
-    })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', () => {
-    User.joins('pets', 'collars', 'pet', 'collars', 'pet', 'collars', 'pet')
   })
 })

--- a/spec/unit/dream/load.spec.ts
+++ b/spec/unit/dream/load.spec.ts
@@ -22,13 +22,6 @@ describe('Dream#load', () => {
     expect(() => user.pets).toThrowError(NonLoadedAssociation)
   })
 
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await user.load('pets', 'collars', 'pet', 'collars', 'pet').execute()
-  })
-
   context('with a transaction', () => {
     it('loads the association', async () => {
       let pets: Pet[] = []

--- a/spec/unit/dream/loadInto.spec.ts
+++ b/spec/unit/dream/loadInto.spec.ts
@@ -25,11 +25,4 @@ describe('Dream.loadInto', () => {
     expect(composition.localizedTexts).toMatchDreamModels([compositionText1, compositionText2])
     expect(compositionAsset.localizedTexts).toMatchDreamModels([compositionAssetText1, compositionAssetText2])
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Composition.loadInto([], 'user', 'balloons', 'user', 'balloons', 'user', 'balloons')
-  })
 })

--- a/spec/unit/dream/pluckEachThrough.spec.ts
+++ b/spec/unit/dream/pluckEachThrough.spec.ts
@@ -58,24 +58,6 @@ describe('Dream.pluckEachThrough', () => {
 
       expect(plucked).toEqual([[edge1.id, edge1.name]])
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await Node.transaction(async txn => {
-        await Node.txn(txn).pluckEachThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', [
-          'edge.id',
-        ])
-      })
-    })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Node.pluckEachThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
   })
 })
 
@@ -149,25 +131,5 @@ describe('Dream#pluckEachThrough', () => {
 
       expect(plucked).toEqual([[edge1.id, edge1.name]])
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await Node.transaction(async txn => {
-        const node = await Node.create({ name: 'N1' })
-        await node
-          .txn(txn)
-          .pluckEachThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
-      })
-    })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    const node = await Node.create({ name: 'N1' })
-    await node.pluckEachThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
   })
 })

--- a/spec/unit/dream/pluckThrough.spec.ts
+++ b/spec/unit/dream/pluckThrough.spec.ts
@@ -50,24 +50,6 @@ describe('Dream.pluckThrough', () => {
 
       expect(plucked).toEqual([[edge1.id, edge1.name]])
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await Node.transaction(async txn => {
-        await Node.txn(txn).pluckThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', [
-          'edge.id',
-        ])
-      })
-    })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Node.pluckThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
   })
 })
 
@@ -132,25 +114,5 @@ describe('Dream#pluckThrough', () => {
 
       expect(plucked).toEqual([[edge1.id, edge1.name]])
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await Node.transaction(async txn => {
-        const node = await Node.create({ name: 'N1' })
-        await node
-          .txn(txn)
-          .pluckThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
-      })
-    })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    const node = await Node.create({ name: 'N1' })
-    await node.pluckThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', ['edge.id'])
   })
 })

--- a/spec/unit/dream/preload.spec.ts
+++ b/spec/unit/dream/preload.spec.ts
@@ -38,15 +38,6 @@ describe('Dream.preload', () => {
 
       expect(reloadedCompositionAssetAudit!.compositionAsset).toMatchDreamModel(compositionAsset)
     })
-
-    // this is skipped, since it is only here to ensure that types are working
-    // from args a-g, which does not actually need to be run, since if this is
-    // broken, tests will fail to compile due to type errors
-    it.skip('permits types a-g', async () => {
-      await ApplicationModel.transaction(txn => {
-        Composition.txn(txn).preload('user', 'balloons', 'user', 'balloons', 'user', 'balloons', 'user')
-      })
-    })
   })
 
   context('STI associations are loaded', () => {
@@ -58,12 +49,5 @@ describe('Dream.preload', () => {
       const users = await User.preload('balloons').all()
       expect(users[0].balloons).toMatchDreamModels([mylar, latex])
     })
-  })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', () => {
-    Composition.preload('user', 'balloons', 'user', 'balloons', 'user', 'balloons')
   })
 })

--- a/spec/unit/query/joins/simple-associations.spec.ts
+++ b/spec/unit/query/joins/simple-associations.spec.ts
@@ -468,11 +468,4 @@ describe('Query#joins with simple associations', () => {
       expect(results).toMatchDreamModels([user])
     })
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', () => {
-    Composition.query().joins('user', 'balloons', 'user', 'balloons', 'user', 'balloons')
-  })
 })

--- a/spec/unit/query/loadInto.spec.ts
+++ b/spec/unit/query/loadInto.spec.ts
@@ -52,11 +52,4 @@ describe('Query#loadInto', () => {
       expect(compositionAsset.currentLocalizedText).toMatchDreamModel(compositionAssetText1)
     })
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Composition.query().loadInto([], 'user', 'balloons', 'user', 'balloons', 'user', 'balloons')
-  })
 })

--- a/spec/unit/query/pluckEachThrough.spec.ts
+++ b/spec/unit/query/pluckEachThrough.spec.ts
@@ -170,13 +170,4 @@ describe('Query#pluckEachThrough', () => {
       })
     })
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Node.query().pluckEachThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', [
-      'edge.id',
-    ])
-  })
 })

--- a/spec/unit/query/pluckThrough.spec.ts
+++ b/spec/unit/query/pluckThrough.spec.ts
@@ -107,13 +107,4 @@ describe('Query#pluckThrough', () => {
       expect(plucked).toEqual(['fred@frewd'])
     })
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', async () => {
-    await Node.query().pluckThrough('edgeNodes', 'edge', 'edgeNodes', 'edge', 'edgeNodes', 'edge', [
-      'edge.id',
-    ])
-  })
 })

--- a/spec/unit/query/preload/simple-associations.spec.ts
+++ b/spec/unit/query/preload/simple-associations.spec.ts
@@ -348,16 +348,4 @@ describe('Query#preload with simple associations', () => {
       })
     })
   })
-
-  // this is skipped, since it is only here to ensure that types are working
-  // from args a-g, which does not actually need to be run, since if this is
-  // broken, tests will fail to compile due to type errors
-  it.skip('permits types a-g', () => {
-    Composition.query().preload(['compositionAssetAudits', 'heartRatings'])
-    Composition.query().preload('user', 'balloons', 'user', 'balloons', 'user', 'balloons')
-    Composition.query().preload('user', 'balloons', 'user', 'balloons', 'user', 'balloons', [
-      'balloonLine',
-      'sandbags',
-    ])
-  })
 })


### PR DESCRIPTION
as a possible next argument for load/preload, joins, pluckThrough, pluckEachThrough