### PR TITLE
'summary', not 'index', for summary serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/cli/generateDreamContent.spec.ts
+++ b/spec/unit/cli/generateDreamContent.spec.ts
@@ -8,7 +8,7 @@ describe('dream generate:model <name> [...attributes]', () => {
         `\
 import { DreamColumn } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import MealTypeSerializer, { MealTypeIndexSerializer } from '../../../test-app/app/serializers/MealTypeSerializer'
+import MealTypeSerializer, { MealTypeSummarySerializer } from '../../../test-app/app/serializers/MealTypeSerializer'
 
 export default class MealType extends ApplicationModel {
   public get table() {
@@ -21,7 +21,7 @@ export default class MealType extends ApplicationModel {
       default: MealTypeSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: MealTypeIndexSerializer<any, any>,
+      summary: MealTypeSummarySerializer<any, any>,
     } as const
   }
 
@@ -42,7 +42,7 @@ export default class MealType extends ApplicationModel {
           `\
 import { DreamColumn } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import UserSerializer, { UserIndexSerializer } from '../../../test-app/app/serializers/UserSerializer'
+import UserSerializer, { UserSummarySerializer } from '../../../test-app/app/serializers/UserSerializer'
 
 export default class User extends ApplicationModel {
   public get table() {
@@ -55,7 +55,7 @@ export default class User extends ApplicationModel {
       default: UserSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: UserIndexSerializer<any, any>,
+      summary: UserSummarySerializer<any, any>,
     } as const
   }
 
@@ -81,7 +81,7 @@ export default class User extends ApplicationModel {
           `\
 import { DreamColumn } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import ChalupaSerializer, { ChalupaIndexSerializer } from '../../../test-app/app/serializers/ChalupaSerializer'
+import ChalupaSerializer, { ChalupaSummarySerializer } from '../../../test-app/app/serializers/ChalupaSerializer'
 import { ToppingEnum, ProteinEnum, MyExistingEnumEnum } from '../../../test-app/db/sync'
 
 export default class Chalupa extends ApplicationModel {
@@ -95,7 +95,7 @@ export default class Chalupa extends ApplicationModel {
       default: ChalupaSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: ChalupaIndexSerializer<any, any>,
+      summary: ChalupaSummarySerializer<any, any>,
     } as const
   }
 
@@ -118,7 +118,7 @@ export default class Chalupa extends ApplicationModel {
           `\
 import { DreamColumn } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import PaperSerializer, { PaperIndexSerializer } from '../../../test-app/app/serializers/PaperSerializer'
+import PaperSerializer, { PaperSummarySerializer } from '../../../test-app/app/serializers/PaperSerializer'
 
 export default class Paper extends ApplicationModel {
   public get table() {
@@ -131,7 +131,7 @@ export default class Paper extends ApplicationModel {
       default: PaperSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: PaperIndexSerializer<any, any>,
+      summary: PaperSummarySerializer<any, any>,
     } as const
   }
 
@@ -153,7 +153,7 @@ export default class Paper extends ApplicationModel {
             `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CompositionSerializer, { CompositionIndexSerializer } from '../../../test-app/app/serializers/CompositionSerializer'
+import CompositionSerializer, { CompositionSummarySerializer } from '../../../test-app/app/serializers/CompositionSerializer'
 import GraphNode from './GraphNode'
 
 export default class Composition extends ApplicationModel {
@@ -167,7 +167,7 @@ export default class Composition extends ApplicationModel {
       default: CompositionSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CompositionIndexSerializer<any, any>,
+      summary: CompositionSummarySerializer<any, any>,
     } as const
   }
 
@@ -190,7 +190,7 @@ export default class Composition extends ApplicationModel {
               `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CatToySerializer, { CatToyIndexSerializer } from '../../../test-app/app/serializers/CatToySerializer'
+import CatToySerializer, { CatToySummarySerializer } from '../../../test-app/app/serializers/CatToySerializer'
 import Cat from './Pet/Domestic/Cat'
 
 export default class CatToy extends ApplicationModel {
@@ -204,7 +204,7 @@ export default class CatToy extends ApplicationModel {
       default: CatToySerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CatToyIndexSerializer<any, any>,
+      summary: CatToySummarySerializer<any, any>,
     } as const
   }
 
@@ -226,7 +226,7 @@ export default class CatToy extends ApplicationModel {
               `\
 import { DreamColumn, HasMany } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CatToySerializer, { CatToyIndexSerializer } from '../../../test-app/app/serializers/CatToySerializer'
+import CatToySerializer, { CatToySummarySerializer } from '../../../test-app/app/serializers/CatToySerializer'
 import Cat from './Pet/Domestic/Cat'
 
 export default class CatToy extends ApplicationModel {
@@ -240,7 +240,7 @@ export default class CatToy extends ApplicationModel {
       default: CatToySerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CatToyIndexSerializer<any, any>,
+      summary: CatToySummarySerializer<any, any>,
     } as const
   }
 
@@ -261,7 +261,7 @@ export default class CatToy extends ApplicationModel {
               `\
 import { DreamColumn, HasOne } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CatToySerializer, { CatToyIndexSerializer } from '../../../test-app/app/serializers/CatToySerializer'
+import CatToySerializer, { CatToySummarySerializer } from '../../../test-app/app/serializers/CatToySerializer'
 import Cat from './Pet/Domestic/Cat'
 
 export default class CatToy extends ApplicationModel {
@@ -275,7 +275,7 @@ export default class CatToy extends ApplicationModel {
       default: CatToySerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CatToyIndexSerializer<any, any>,
+      summary: CatToySummarySerializer<any, any>,
     } as const
   }
 
@@ -296,7 +296,7 @@ export default class CatToy extends ApplicationModel {
               `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from '../../ApplicationModel'
-import PetDomesticCatSerializer, { PetDomesticCatIndexSerializer } from '../../../../../test-app/app/serializers/Pet/Domestic/CatSerializer'
+import PetDomesticCatSerializer, { PetDomesticCatSummarySerializer } from '../../../../../test-app/app/serializers/Pet/Domestic/CatSerializer'
 import GraphNode from '../../GraphNode'
 
 export default class Cat extends ApplicationModel {
@@ -310,7 +310,7 @@ export default class Cat extends ApplicationModel {
       default: PetDomesticCatSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: PetDomesticCatIndexSerializer<any, any>,
+      summary: PetDomesticCatSummarySerializer<any, any>,
     } as const
   }
 
@@ -332,7 +332,7 @@ export default class Cat extends ApplicationModel {
               `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from '../../ApplicationModel'
-import PetDomesticCatSerializer, { PetDomesticCatIndexSerializer } from '../../../../../test-app/app/serializers/Pet/Domestic/CatSerializer'
+import PetDomesticCatSerializer, { PetDomesticCatSummarySerializer } from '../../../../../test-app/app/serializers/Pet/Domestic/CatSerializer'
 import Dog from '../../Pet/Domestic/Dog'
 
 export default class Cat extends ApplicationModel {
@@ -346,7 +346,7 @@ export default class Cat extends ApplicationModel {
       default: PetDomesticCatSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: PetDomesticCatIndexSerializer<any, any>,
+      summary: PetDomesticCatSummarySerializer<any, any>,
     } as const
   }
 
@@ -368,7 +368,7 @@ export default class Cat extends ApplicationModel {
               `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from '../../ApplicationModel'
-import PetWildCatSerializer, { PetWildCatIndexSerializer } from '../../../../../test-app/app/serializers/Pet/Wild/CatSerializer'
+import PetWildCatSerializer, { PetWildCatSummarySerializer } from '../../../../../test-app/app/serializers/Pet/Wild/CatSerializer'
 import Dog from '../../Pet/Domestic/Dog'
 
 export default class Cat extends ApplicationModel {
@@ -382,7 +382,7 @@ export default class Cat extends ApplicationModel {
       default: PetWildCatSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: PetWildCatIndexSerializer<any, any>,
+      summary: PetWildCatSummarySerializer<any, any>,
     } as const
   }
 
@@ -405,7 +405,7 @@ export default class Cat extends ApplicationModel {
             `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CompositionSerializer, { CompositionIndexSerializer } from '../../../test-app/app/serializers/CompositionSerializer'
+import CompositionSerializer, { CompositionSummarySerializer } from '../../../test-app/app/serializers/CompositionSerializer'
 import User from './User'
 import Chalupa from './Chalupa'
 
@@ -420,7 +420,7 @@ export default class Composition extends ApplicationModel {
       default: CompositionSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CompositionIndexSerializer<any, any>,
+      summary: CompositionSummarySerializer<any, any>,
     } as const
   }
 
@@ -448,7 +448,7 @@ export default class Composition extends ApplicationModel {
             `\
 import { DreamColumn, HasOne } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CompositionSerializer, { CompositionIndexSerializer } from '../../../test-app/app/serializers/CompositionSerializer'
+import CompositionSerializer, { CompositionSummarySerializer } from '../../../test-app/app/serializers/CompositionSerializer'
 import User from './User'
 
 export default class Composition extends ApplicationModel {
@@ -462,7 +462,7 @@ export default class Composition extends ApplicationModel {
       default: CompositionSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CompositionIndexSerializer<any, any>,
+      summary: CompositionSummarySerializer<any, any>,
     } as const
   }
 
@@ -485,7 +485,7 @@ export default class Composition extends ApplicationModel {
             `\
 import { DreamColumn, HasMany } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import UserSerializer, { UserIndexSerializer } from '../../../test-app/app/serializers/UserSerializer'
+import UserSerializer, { UserSummarySerializer } from '../../../test-app/app/serializers/UserSerializer'
 import Composition from './Composition'
 
 export default class User extends ApplicationModel {
@@ -499,7 +499,7 @@ export default class User extends ApplicationModel {
       default: UserSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: UserIndexSerializer<any, any>,
+      summary: UserSummarySerializer<any, any>,
     } as const
   }
 
@@ -522,7 +522,7 @@ export default class User extends ApplicationModel {
             `\
 import { DreamColumn, BelongsTo } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import CompositionSerializer, { CompositionIndexSerializer } from '../../../test-app/app/serializers/CompositionSerializer'
+import CompositionSerializer, { CompositionSummarySerializer } from '../../../test-app/app/serializers/CompositionSerializer'
 import User from './User'
 
 export default class Composition extends ApplicationModel {
@@ -536,7 +536,7 @@ export default class Composition extends ApplicationModel {
       default: CompositionSerializer<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: CompositionIndexSerializer<any, any>,
+      summary: CompositionSummarySerializer<any, any>,
     } as const
   }
 

--- a/spec/unit/cli/generateSerializerContent.spec.ts
+++ b/spec/unit/cli/generateSerializerContent.spec.ts
@@ -43,7 +43,7 @@ export default class UserSerializer extends DreamSerializer {
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -54,7 +54,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute()
   public loggedInAt: DreamColumn<User, 'loggedInAt'>
 }`
@@ -72,7 +72,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import Admin from '../../models/User/Admin'
 
-export class UserAdminIndexSerializer<
+export class UserAdminSummarySerializer<
   DataType extends Admin,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -83,7 +83,7 @@ export class UserAdminIndexSerializer<
 export default class UserAdminSerializer<
   DataType extends Admin,
   Passthrough extends object
-> extends UserAdminIndexSerializer<DataType, Passthrough> {
+> extends UserAdminSummarySerializer<DataType, Passthrough> {
   
 }`
           )
@@ -101,7 +101,7 @@ export default class UserAdminSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -112,7 +112,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('string')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -130,7 +130,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -141,7 +141,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('number')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -159,7 +159,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -170,7 +170,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('json')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -188,7 +188,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -199,7 +199,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('json')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -217,7 +217,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -228,7 +228,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('decimal', { precision: 2 })
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -246,7 +246,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -257,7 +257,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('number')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -275,7 +275,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -286,7 +286,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('string')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -304,7 +304,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -315,7 +315,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('string')
   public howyadoin: DreamColumn<User, 'howyadoin'>
 }\
@@ -333,7 +333,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -344,7 +344,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('datetime')
   public loggedInAt: DreamColumn<User, 'loggedInAt'>
 }\
@@ -362,7 +362,7 @@ export default class UserSerializer<
 import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -373,7 +373,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('date')
   public loggedInOn: DreamColumn<User, 'loggedInOn'>
 }\
@@ -394,7 +394,7 @@ import { DreamSerializer, Attribute, DreamColumn } from '@rvohealth/dream'
 import { ToppingEnum } from '../../../test-app/db/sync'
 import User from '../models/User'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -405,7 +405,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @Attribute('enum:ToppingEnum')
   public topping: DreamColumn<User, 'topping'>
 }\
@@ -425,7 +425,7 @@ import { DreamSerializer, Attribute, DreamColumn, RendersOne } from '@rvohealth/
 import User from '../models/User'
 import Organization from '../models/Organization'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -436,7 +436,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @RendersOne()
   public organization: Organization
 }`
@@ -454,7 +454,7 @@ import { DreamSerializer, Attribute, DreamColumn, RendersOne } from '@rvohealth/
 import User from '../models/User'
 import Organization from '../models/Organization'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -465,7 +465,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @RendersOne()
   public organization: Organization
 }`
@@ -483,7 +483,7 @@ import { DreamSerializer, Attribute, DreamColumn, RendersMany } from '@rvohealth
 import User from '../models/User'
 import Organization from '../models/Organization'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -494,7 +494,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @RendersMany()
   public organizations: Organization[]
 }`
@@ -511,7 +511,7 @@ import { DreamSerializer, Attribute, DreamColumn, RendersMany } from '@rvohealth
 import User from '../models/User'
 import Paper from '../models/Paper'
 
-export class UserIndexSerializer<
+export class UserSummarySerializer<
   DataType extends User,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -522,7 +522,7 @@ export class UserIndexSerializer<
 export default class UserSerializer<
   DataType extends User,
   Passthrough extends object
-> extends UserIndexSerializer<DataType, Passthrough> {
+> extends UserSummarySerializer<DataType, Passthrough> {
   @RendersMany()
   public paper: Paper[]
 }`
@@ -543,7 +543,7 @@ import { DreamSerializer, Attribute, DreamColumn, RendersOne } from '@rvohealth/
 import Admin from '../../models/User/Admin'
 import MyModel from '../../models/Double/Nested/MyModel'
 
-export class UserAdminIndexSerializer<
+export class UserAdminSummarySerializer<
   DataType extends Admin,
   Passthrough extends object
 > extends DreamSerializer<DataType, Passthrough> {
@@ -554,7 +554,7 @@ export class UserAdminIndexSerializer<
 export default class UserAdminSerializer<
   DataType extends Admin,
   Passthrough extends object
-> extends UserAdminIndexSerializer<DataType, Passthrough> {
+> extends UserAdminSummarySerializer<DataType, Passthrough> {
   @RendersOne()
   public myModel: MyModel
 }`

--- a/spec/unit/serializer/render.spec.ts
+++ b/spec/unit/serializer/render.spec.ts
@@ -596,7 +596,7 @@ describe('DreamSerializer#render', () => {
 
       context('when a named serializer is specified', () => {
         class UserSerializer extends DreamSerializer {
-          @RendersMany({ serializer: 'index' })
+          @RendersMany({ serializer: 'summary' })
           public pets: Pet[]
         }
 
@@ -844,7 +844,7 @@ describe('DreamSerializer#render', () => {
 
       context('when a named serializer is specified', () => {
         class PetSerializer extends DreamSerializer {
-          @RendersOne({ serializer: 'index' })
+          @RendersOne({ serializer: 'summary' })
           public user: User
         }
 

--- a/src/helpers/cli/generateDreamContent.ts
+++ b/src/helpers/cli/generateDreamContent.ts
@@ -101,7 +101,7 @@ export default class ${modelClassName} extends ApplicationModel {
       default: ${serializerNameFromModelName(modelName)}<any, any>,
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      index: ${serializerIndexNameFromModelName(modelName)}<any, any>,
+      summary: ${serializerSummaryNameFromModelName(modelName)}<any, any>,
     } as const
   }
 
@@ -141,8 +141,8 @@ async function buildSerializerImportStatement(modelName: string) {
     relativeSerializerPathFromModelName(modelName)
   )
   const serializerClassName = serializerNameFromModelName(modelName)
-  const serializerIndexClassName = serializerIndexNameFromModelName(modelName)
-  const importStatement = `import ${serializerClassName}, { ${serializerIndexClassName} } from '${serializerPath}'`
+  const serializerSummaryClassName = serializerSummaryNameFromModelName(modelName)
+  const importStatement = `import ${serializerClassName}, { ${serializerSummaryClassName} } from '${serializerPath}'`
   return importStatement
 }
 
@@ -155,8 +155,8 @@ function serializerNameFromModelName(modelName: string) {
   )
 }
 
-function serializerIndexNameFromModelName(modelName: string) {
-  return serializerNameFromModelName(modelName).replace(/Serializer$/, 'IndexSerializer')
+function serializerSummaryNameFromModelName(modelName: string) {
+  return serializerNameFromModelName(modelName).replace(/Serializer$/, 'SummarySerializer')
 }
 
 function relativeSerializerPathFromModelName(modelName: string) {

--- a/src/helpers/cli/generateSerializerContent.ts
+++ b/src/helpers/cli/generateSerializerContent.ts
@@ -15,7 +15,7 @@ export default async function generateSerializerContent(
   await initializeDream()
 
   const serializerClass = fullyQualifiedClassNameFromRawStr(fullyQualifiedSerializerName)
-  const serializerIndexClass = fullyQualifiedIndexClassNameFromRawStr(fullyQualifiedSerializerName)
+  const serializerSummaryClass = fullyQualifiedSummaryClassNameFromRawStr(fullyQualifiedSerializerName)
   const enumImports: string[] = []
   const additionalImports: string[] = []
   let relatedModelImport = ''
@@ -34,7 +34,7 @@ export default async function generateSerializerContent(
 >`
     dreamSerializerTypeArgs = `<DataType, Passthrough>`
     dreamImports.push('DreamColumn')
-    extendedClass = serializerIndexClass
+    extendedClass = serializerSummaryClass
   }
 
   let luxonImport = ''
@@ -71,9 +71,9 @@ export default async function generateSerializerContent(
 
   const additionalImportsStr = additionalImports.length ? '\n' + uniq(additionalImports).join('\n') : ''
 
-  let indexSerializer = ''
+  let summarySerializer = ''
   if (modelClass) {
-    indexSerializer = `
+    summarySerializer = `
 
 export class ${extendedClass}${dataTypeCapture} extends DreamSerializer${dreamSerializerTypeArgs} {
   @Attribute('string')
@@ -84,7 +84,7 @@ export class ${extendedClass}${dataTypeCapture} extends DreamSerializer${dreamSe
   return `\
 ${luxonImport}import { ${dreamImports.join(
     ', '
-  )} } from '@rvohealth/dream'${additionalImportsStr}${relatedModelImport}${additionalModelImports.join('')}${indexSerializer}
+  )} } from '@rvohealth/dream'${additionalImportsStr}${relatedModelImport}${additionalModelImports.join('')}${summarySerializer}
 
 export default class ${serializerClass}${dataTypeCapture} extends ${extendedClass}${dreamSerializerTypeArgs} {
   ${attributes
@@ -190,8 +190,8 @@ function fullyQualifiedClassNameFromRawStr(className: string) {
     .join('')
 }
 
-function fullyQualifiedIndexClassNameFromRawStr(className: string) {
-  return fullyQualifiedClassNameFromRawStr(className).replace(/Serializer$/, 'IndexSerializer')
+function fullyQualifiedSummaryClassNameFromRawStr(className: string) {
+  return fullyQualifiedClassNameFromRawStr(className).replace(/Serializer$/, 'SummarySerializer')
 }
 
 function hasJsType(attributes: string[], expectedType: 'DateTime' | 'CalendarDate') {

--- a/test-app/app/models/Pet.ts
+++ b/test-app/app/models/Pet.ts
@@ -7,7 +7,7 @@ import User from './User'
 import { DreamColumn, IdType } from '../../../src/dream/types'
 import BeforeDestroy from '../../../src/decorators/hooks/before-destroy'
 import Collar from './Collar'
-import PetSerializer, { PetIndexSerializer } from '../serializers/PetSerializer'
+import PetSerializer, { PetSummarySerializer } from '../serializers/PetSerializer'
 import ApplicationModel from './ApplicationModel'
 import Balloon from './Balloon'
 import PetUnderstudyJoinModel from './PetUnderstudyJoinModel'
@@ -22,7 +22,7 @@ export default class Pet extends ApplicationModel {
   public get serializers() {
     return {
       default: PetSerializer<any, any>,
-      index: PetIndexSerializer<any, any>,
+      summary: PetSummarySerializer<any, any>,
     } as const
   }
 

--- a/test-app/app/models/User.ts
+++ b/test-app/app/models/User.ts
@@ -21,7 +21,7 @@ import BalloonLine from './BalloonLine'
 import Post from './Post'
 import Rating from './Rating'
 import Collar from './Collar'
-import UserSerializer, { UserIndexSerializer } from '../serializers/UserSerializer'
+import UserSerializer, { UserSummarySerializer } from '../serializers/UserSerializer'
 
 export default class User extends ApplicationModel {
   public get table() {
@@ -31,7 +31,7 @@ export default class User extends ApplicationModel {
   public get serializers() {
     return {
       default: UserSerializer<any, any>,
-      index: UserIndexSerializer<any, any>,
+      summary: UserSummarySerializer<any, any>,
     } as const
   }
 

--- a/test-app/app/serializers/PetSerializer.ts
+++ b/test-app/app/serializers/PetSerializer.ts
@@ -25,7 +25,7 @@ export default class PetSerializer<DataType extends Pet, Passthrough extends obj
   public ratings: Rating[]
 }
 
-export class PetIndexSerializer<DataType extends Pet, Passthrough extends object> extends DreamSerializer<
+export class PetSummarySerializer<DataType extends Pet, Passthrough extends object> extends DreamSerializer<
   DataType,
   Passthrough
 > {

--- a/test-app/app/serializers/UserSerializer.ts
+++ b/test-app/app/serializers/UserSerializer.ts
@@ -18,7 +18,7 @@ export default class UserSerializer<
   public birthdate: CalendarDate
 }
 
-export class UserIndexSerializer<DataType extends User, Passthrough extends object> extends DreamSerializer<
+export class UserSummarySerializer<DataType extends User, Passthrough extends object> extends DreamSerializer<
   DataType,
   Passthrough
 > {


### PR DESCRIPTION
name. Even though the summary serializer will
often be used on index endpoints 'index' means
the default in many Javascript contexts, so
is confusing given that we have a separate,
'default' context.