### PR TITLE
When strict null checks are disabled, testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",


### PR DESCRIPTION
whether null extends non-null types evaluates to true, so we need to explicitly test whether a possibly null type extends null first and only if that evaluates to false can we check that type against a non-null type.

That is, given:
```
type A = null
type T = A extends string[] ? 'x' : 'y'
```
in a project with strict null checks turned on, T will be 'y', but in a project with strict null checks turned off, T will be 'x'.

To fix this, we explicitly test against null first:
```
type A = null
type T = A extends null ? 'y' : A extends string[] ? 'x' : never
```