### PR TITLE
Clearer type names and fixed RelaxedJoinsWhereStatement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/src/decorators/associations/shared.ts
+++ b/src/decorators/associations/shared.ts
@@ -56,10 +56,10 @@ export type AssociatedModelParam<
 export type PassthroughWhere<AllColumns extends string[]> = Partial<Record<AllColumns[number], any>>
 
 type DreamSelectable<DB, Schema, TableName extends AssociationTableNames<DB, Schema> & keyof DB> = Partial<
-  Record<keyof DB[TableName], WhereClauseValues<DB>>
+  Record<keyof DB[TableName], NonKyselySupportedSupplementalWhereClauseValues<DB>>
 >
 
-export type WhereClauseValues<DB> =
+type NonKyselySupportedSupplementalWhereClauseValues<DB> =
   | Range<DateTime>
   | (() => Range<DateTime>)
   | Range<CalendarDate>
@@ -67,6 +67,7 @@ export type WhereClauseValues<DB> =
   | Range<number>
   | OpsStatement<any, any>
   | CurriedOpsStatement<any, any, any>
+  // the non-array allowed types are set by Kysely in Updateable
   | (IdType | string | number | bigint)[]
   | SelectQueryBuilder<DB, keyof DB, any>
 
@@ -77,7 +78,9 @@ type AssociationDreamSelectable<
 > = Partial<
   Record<
     keyof DB[TableName],
-    WhereClauseValues<DB> | typeof DreamConst.passthrough | typeof DreamConst.requiredWhereClause
+    | NonKyselySupportedSupplementalWhereClauseValues<DB>
+    | typeof DreamConst.passthrough
+    | typeof DreamConst.requiredWhereClause
   >
 >
 

--- a/src/dream/types.ts
+++ b/src/dream/types.ts
@@ -4,7 +4,7 @@ import { Updateable, ColumnType } from 'kysely'
 import { AssociationTableNames } from '../db/reflections'
 import Dream from '../dream'
 import { FilterInterface, Inc, ReadonlyTail } from '../helpers/typeutils'
-import { AssociatedModelParam, WhereClauseValues, WhereStatement } from '../decorators/associations/shared'
+import { AssociatedModelParam, WhereStatement } from '../decorators/associations/shared'
 import OpsStatement from '../ops/ops-statement'
 import { FindEachOpts } from './query'
 import CalendarDate from '../helpers/CalendarDate'
@@ -251,8 +251,11 @@ export type RelaxedPreloadWhereStatement<DB, Schema, Depth extends number = 0> =
 export type RelaxedJoinsWhereStatement<DB, Schema, Depth extends number = 0> = Depth extends 7
   ? object
   : {
-      [key: string]: RelaxedJoinsWhereStatement<DB, Schema, Inc<Depth>> | WhereClauseValues<DB> | object
+      [key: string]: RelaxedJoinsWhereStatement<DB, Schema, Inc<Depth>> | FakeWhereClauseValue | object
     }
+
+// Just need something that is not an object, but that could be an array and also null
+type FakeWhereClauseValue = string | string[] | number | number[] | null
 
 export type TableOrAssociationName<Schema> = (keyof Schema & string) | (keyof Schema[keyof Schema] & string)
 


### PR DESCRIPTION
since the former WhereClauseValues doesn't include non-array primitive types