### PR TITLE
[1] pluckEach, pluckEachThrough order by primary key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/query/pluck.spec.ts
+++ b/spec/unit/query/pluck.spec.ts
@@ -1,6 +1,6 @@
-import User from '../../../test-app/app/models/User'
 import ops from '../../../src/ops'
 import Edge from '../../../test-app/app/models/Graph/Edge'
+import User from '../../../test-app/app/models/User'
 
 describe('Query#pluck', () => {
   let user1: User

--- a/spec/unit/query/pluckEachThrough.spec.ts
+++ b/spec/unit/query/pluckEachThrough.spec.ts
@@ -33,6 +33,23 @@ describe('Query#pluckEachThrough', () => {
     expect(plucked).toEqual([[edge1.id, edge1.name]])
   })
 
+  context('when primary key is not one of the plucked fields', () => {
+    it('uses primary key for ordering, but discards primary key from results', async () => {
+      const node = await Node.create({ name: 'N1' })
+      const edge1 = await Edge.create({ name: 'E1' })
+      const edge2 = await Edge.create({ name: 'E2' })
+      await EdgeNode.create({ node, edge: edge1 })
+      await EdgeNode.create({ node, edge: edge2 })
+
+      const plucked: any[] = []
+      await Node.query().pluckEachThrough('edgeNodes', 'edge', ['edge.name'], arr => {
+        plucked.push(arr)
+      })
+
+      expect(plucked).toEqual([edge1.name, edge2.name])
+    })
+  })
+
   context('with invalid arguments', () => {
     context('when the cb function is not provided', () => {
       it('raises a targeted exception', async () => {


### PR DESCRIPTION
Ensure that both pluckEach and pluckEach through order by primary key, even if a different order statement is passed

close https://rvohealth.atlassian.net/browse/PDTC-5516