### PR TITLE
[Bug] type `marshallDbValues` entries array so we dont get type collisions in usage

### DIFF
--- a/src/helpers/marshalDBArrayValue.ts
+++ b/src/helpers/marshalDBArrayValue.ts
@@ -37,7 +37,7 @@ function parsePostgresArray(source: string, transform: any, nested = false) {
   let quote = false
   let position = 0
   let dimension = 0
-  const entries: Array<any> = []
+  const entries: any[] = []
   let recorded = ''
 
   const newEntry = function (includeEmpty: boolean = false) {


### PR DESCRIPTION
I was getting this error in wellos-central when trying to remove the file `UserSerializer` from the `strictNullChecks` exclude list:

```
➜ yarn run strict-null-checks:check
yarn run v1.22.19
$ npx tsc -p ./tsconfig.strictNullChecks.json --noEmit
node_modules/@rvohealth/dream/src/helpers/marshalDBArrayValue.ts:55:20 - error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.

55       entries.push(entry)
                      ~~~~~

node_modules/@rvohealth/dream/src/helpers/marshalDBArrayValue.ts:85:22 - error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.

85         entries.push(parser.entries)
                        ~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/@rvohealth/dream/src/helpers/marshalDBArrayValue.ts:55

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Simply specifying that the type of this array is `Array<any>` seems to fix the strict null check error.