### PR TITLE
Must not call the function because this function is called as part of…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "dream orm",
   "main": "src/index.ts",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/src/serializer/decorators/associations/shared.ts
+++ b/src/serializer/decorators/associations/shared.ts
@@ -1,6 +1,6 @@
 import { DreamConst, SerializableClassOrClasses } from '../../../dream/types'
 import hasSerializersGetter from '../helpers/hasSerializersGetter'
-import serializerAssociationToDreamSerializer from '../helpers/serializerAssociationToDreamSerializer'
+import serializerAssociationToDreamSerializer from '../helpers/maybeSerializableToDreamSerializerCallbackFunction'
 
 export type SerializableAssociationType = 'RendersOne' | 'RendersMany'
 

--- a/src/serializer/decorators/helpers/maybeSerializableToDreamSerializerCallbackFunction.ts
+++ b/src/serializer/decorators/helpers/maybeSerializableToDreamSerializerCallbackFunction.ts
@@ -1,19 +1,19 @@
-import DreamSerializer from '../..'
 import Dream from '../../../dream'
 import { DreamSerializerCallback, SerializableClassOrClasses } from '../../../dream/types'
 import hasSerializersGetter from './hasSerializersGetter'
 
 export default function (
   dreamOrSerializerClass: SerializableClassOrClasses | null
-): typeof DreamSerializer | null {
+): DreamSerializerCallback | null {
   if (dreamOrSerializerClass === null) return null
   if (Array.isArray(dreamOrSerializerClass)) return null
   if ((dreamOrSerializerClass as unknown as typeof Dream).isDream) return null
   if (hasSerializersGetter(dreamOrSerializerClass)) return null
-  if (
-    dreamOrSerializerClass instanceof Function &&
-    (dreamOrSerializerClass as DreamSerializerCallback)()?.isDreamSerializer
-  )
-    return (dreamOrSerializerClass as DreamSerializerCallback)()
+
+  // this must not call the function because this function is called as part of decorator
+  // execution, which happens at file load time and creates circular dependencies if the
+  // class is referenced directly during file load
+  if (dreamOrSerializerClass instanceof Function) return dreamOrSerializerClass as DreamSerializerCallback
+
   return null
 }

--- a/src/serializer/index.ts
+++ b/src/serializer/index.ts
@@ -21,7 +21,7 @@ import round from '../helpers/round'
 import snakeify from '../helpers/snakeify'
 import { DreamSerializerAssociationStatement } from './decorators/associations/shared'
 import { AttributeStatement, SerializableTypes } from './decorators/attribute'
-import serializerAssociationToDreamSerializer from './decorators/helpers/serializerAssociationToDreamSerializer'
+import maybeSerializableToDreamSerializerCallbackFunction from './decorators/helpers/maybeSerializableToDreamSerializerCallbackFunction'
 
 export default class DreamSerializer<DataType = any, PassthroughDataType = any> {
   public static attributeStatements: AttributeStatement[] = []
@@ -57,8 +57,10 @@ export default class DreamSerializer<DataType = any, PassthroughDataType = any> 
   public static getAssociatedSerializersForOpenapi(
     associationStatement: DreamSerializerAssociationStatement
   ): (typeof DreamSerializer<any, any>)[] | null {
-    const serializer = serializerAssociationToDreamSerializer(associationStatement.dreamOrSerializerClass)
-    if (serializer) return [serializer]
+    const serializer = maybeSerializableToDreamSerializerCallbackFunction(
+      associationStatement.dreamOrSerializerClass
+    )
+    if (serializer) return [serializer()]
 
     let classOrClasses =
       associationStatement.dreamOrSerializerClass as SerializableClassOrSerializerCallback[]
@@ -82,11 +84,11 @@ export default class DreamSerializer<DataType = any, PassthroughDataType = any> 
     associatedData: SerializableDreamOrViewModel,
     associationStatement: DreamSerializerAssociationStatement
   ): typeof DreamSerializer<any, any> | null {
-    const dreamSerializerOrNull = serializerAssociationToDreamSerializer(
+    const dreamSerializerCallbackFunctionOrNull = maybeSerializableToDreamSerializerCallbackFunction(
       associationStatement.dreamOrSerializerClass
     )
 
-    if (dreamSerializerOrNull) return dreamSerializerOrNull
+    if (dreamSerializerCallbackFunctionOrNull) return dreamSerializerCallbackFunctionOrNull()
     return inferSerializerFromDreamOrViewModel(associatedData, associationStatement.serializerKey)
   }
 


### PR DESCRIPTION
… decorator

execution, which happens at file load time and creates circular dependencies if the class is referenced directly during file load