### PR TITLE
Use node-postgres types setTypeParser to serialize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/initialization.spec.ts
+++ b/spec/unit/dream/initialization.spec.ts
@@ -51,17 +51,33 @@ describe('Dream initialization', () => {
   })
 
   context('a string is passed into a datetime field', () => {
-    it('converts the datetime string to a luxon date', () => {
+    it('converts the datetime string to a DateTime', () => {
       const nowString = DateTime.now().toISO()
       const user = User.new({ deletedAt: nowString as any })
-      expect(user.deletedAt).toEqual(DateTime.fromISO(nowString))
+      expect(user.deletedAt).toEqualDateTime(DateTime.fromISO(nowString))
+    })
+  })
+
+  context('a DateTime in a non-UTC timezone, passed into a datetime field', () => {
+    it('is converted to UTC', () => {
+      const dateString = DateTime.fromISO('2024-09-05T10:42:16.603-04:00')
+      const user = User.new({ deletedAt: dateString as any })
+      expect(user.deletedAt?.toISO()).toEqual('2024-09-05T14:42:16.603Z')
     })
   })
 
   context('a string is passed into a date field', () => {
-    it('converts the date string to a luxon date', () => {
+    it('converts the date string to a CalendarDate', () => {
       const user = User.new({ birthdate: '2000-10-10' as any })
-      expect(user.birthdate).toEqual(CalendarDate.fromISO('2000-10-10'))
+      expect(user.birthdate).toEqualCalendarDate(CalendarDate.fromISO('2000-10-10'))
+    })
+  })
+
+  context('a datetime string in non UTC is passed into a date field', () => {
+    it('is converted to a CalendarDate with the date matching the original timezone date', () => {
+      const dateString = '2024-09-05T22:42:16.603-04:00'
+      const user = User.new({ birthdate: dateString as any })
+      expect(user.birthdate).toEqualCalendarDate(CalendarDate.fromISO('2024-09-05'))
     })
   })
 
@@ -80,7 +96,7 @@ describe('Dream initialization', () => {
   })
 
   context('an object is marshaled as a javascript date by kysely', () => {
-    it('converts the date to a luxon date', async () => {
+    it('converts the date to a DateTime', async () => {
       const user = await User.create({ email: 'fred@', password: 'howyadoin' })
       const u = await User.find(user.id)
       expect(u!.createdAt.constructor).toEqual(DateTime)

--- a/spec/unit/helpers/CalendarDate.spec.ts
+++ b/spec/unit/helpers/CalendarDate.spec.ts
@@ -117,6 +117,20 @@ describe('CalendarDate', () => {
     })
   })
 
+  describe('.fromSQL', () => {
+    it('creates a valid CalendarDate', () => {
+      const calendarDate = CalendarDate.fromSQL('2024-03-02')
+      expect(calendarDate.isValid).toBe(true)
+    })
+
+    context('with an invalid date string', () => {
+      it('creates an invalid CalendarDate', () => {
+        const calendarDate = CalendarDate.fromSQL('2023-02-29')
+        expect(calendarDate.isValid).toBe(false)
+      })
+    })
+  })
+
   describe('.fromObject', () => {
     it('creates a valid CalendarDate', () => {
       const calendarDate = CalendarDate.fromObject({ year: 2023, month: 6, day: 16 })

--- a/src/dream-application/index.ts
+++ b/src/dream-application/index.ts
@@ -1,7 +1,9 @@
+import { types } from 'pg'
 import Dream from '../dream'
 import { primaryKeyTypes } from '../dream/types'
 import DreamApplicationInitMissingCallToLoadModels from '../exceptions/dream-application/init-missing-call-to-load-models'
 import DreamApplicationInitMissingMissingProjectRoot from '../exceptions/dream-application/init-missing-project-root'
+import { parseDate, parseDatetime, parseDecimal } from '../helpers/customPgParsers'
 import DreamSerializer from '../serializer'
 import { cacheDreamApplication, getCachedDreamApplicationOrFail } from './cache'
 import loadModels, { getModelsOrFail } from './helpers/loadModels'
@@ -26,6 +28,11 @@ export default class DreamApplication {
     opts: Partial<DreamApplicationOpts> = {},
     deferCb?: (dreamApp: DreamApplication) => Promise<void> | void
   ) {
+    types.setTypeParser(types.builtins.DATE, parseDate)
+    types.setTypeParser(types.builtins.TIMESTAMP, parseDatetime)
+    types.setTypeParser(types.builtins.TIMESTAMPTZ, parseDatetime)
+    types.setTypeParser(types.builtins.NUMERIC, parseDecimal)
+
     const dreamApp = new DreamApplication(opts)
     await cb(dreamApp)
 

--- a/src/helpers/CalendarDate.ts
+++ b/src/helpers/CalendarDate.ts
@@ -54,6 +54,10 @@ export default class CalendarDate {
     else return new CalendarDate(DateTime.fromISO(str, { setZone: true }))
   }
 
+  public static fromSQL(str: string): CalendarDate {
+    return new CalendarDate(DateTime.fromSQL(str, { zone: 'UTC' }))
+  }
+
   public static fromObject(obj: DateObjectUnits, opts?: DateTimeJSOptions): CalendarDate {
     return new CalendarDate(DateTime.fromObject(obj, opts))
   }

--- a/src/helpers/customPgParsers.ts
+++ b/src/helpers/customPgParsers.ts
@@ -1,0 +1,14 @@
+import { DateTime } from 'luxon'
+import CalendarDate from './CalendarDate'
+
+export const parseDate = (dateString: string | null | undefined) => {
+  return dateString ? CalendarDate.fromSQL(dateString) : dateString
+}
+
+export const parseDatetime = (datetimeString: string | null | undefined) => {
+  return datetimeString ? DateTime.fromSQL(datetimeString, { zone: 'UTC' }) : datetimeString
+}
+
+export const parseDecimal = (numberString: string | null | undefined) => {
+  return numberString ? parseFloat(numberString) : numberString
+}


### PR DESCRIPTION
date columns directly to CalendarDate objects and
datetime columns directly to DateTime objects,
not going through Javascript Date first