### PR TITLE
Storing in a non TZ datetime column truncates timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/create.spec.ts
+++ b/spec/unit/dream/create.spec.ts
@@ -263,13 +263,13 @@ describe('Dream.create', () => {
     })
 
     context('with a string representation of a datetime', () => {
-      it('creates the model with the specified datetime', async () => {
+      it('creates the model with the specified datetime, converting to UTC  before saving', async () => {
         const aTime = DateTime.now().minus({ days: 7 })
 
         const user = await User.create({
           email: 'ham@',
           password: 'chalupas',
-          deletedAt: aTime.toISO() as any,
+          deletedAt: aTime.setZone('America/Chicago').toISO() as any,
         })
 
         const reloaded = await User.removeAllDefaultScopes().find(user.id)
@@ -304,6 +304,19 @@ describe('Dream.create', () => {
 
         const reloaded = await User.removeAllDefaultScopes().find(user.id)
         expect(reloaded!.birthdate!.toISODate()).toEqual(dateString)
+      })
+    })
+
+    context('with a string representation of a datetime', () => {
+      it('creates the model with the specified date', async () => {
+        const user = await User.create({
+          email: 'ham@',
+          password: 'chalupas',
+          birthdate: '2024-09-17T21:03:24.524-05:00' as any,
+        })
+
+        const reloaded = await User.removeAllDefaultScopes().find(user.id)
+        expect(reloaded!.birthdate!.toISODate()).toEqual('2024-09-17')
       })
     })
   })

--- a/spec/unit/dream/update.spec.ts
+++ b/spec/unit/dream/update.spec.ts
@@ -359,7 +359,7 @@ describe('Dream#update', () => {
     context('with a string representation of a datetime', () => {
       it('updates to the datetime', async () => {
         const newTime = DateTime.now().minus({ days: 7 })
-        await user.update({ deletedAt: newTime.toISO() as any })
+        await user.update({ deletedAt: newTime.setZone('America/Chicago').toISO() as any })
         const reloaded = await User.removeAllDefaultScopes().find(user.id)
         expect(reloaded!.deletedAt).toEqualDateTime(newTime)
       })

--- a/src/helpers/sqlAttributes.ts
+++ b/src/helpers/sqlAttributes.ts
@@ -1,13 +1,18 @@
 import { DateTime } from 'luxon'
 import Dream from '../dream'
 import CalendarDate from './CalendarDate'
+import isDateTimeColumn from './db/types/isDateTimeColumn'
+import { isString } from './typechecks'
 
 export default function sqlAttributes(dream: Dream) {
   const attributes = dream.dirtyAttributes()
 
   return Object.keys(attributes).reduce(
     (result, key) => {
-      const val = attributes[key]
+      let val = attributes[key]
+
+      if (isString(val) && isDateTimeColumn(dream.constructor as typeof Dream, key))
+        val = DateTime.fromISO(val, { zone: 'UTC' })
 
       if (val instanceof DateTime || val instanceof CalendarDate) {
         // Converting toJSDate resulted in the correct timezone, but even with process.env.TZ=UTC,


### PR DESCRIPTION
information, altering the aboslute time meaning of the datetime. Convert to UTC first to avoid this