### PR TITLE
raise hard exception if where clause receives undefined val

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/associations/associationQuery.spec.ts
+++ b/spec/unit/dream/associations/associationQuery.spec.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 import MissingRequiredAssociationWhereClause from '../../../../src/exceptions/associations/missing-required-association-where-clause'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import ApplicationModel from '../../../../test-app/app/models/ApplicationModel'
 import Latex from '../../../../test-app/app/models/Balloon/Latex'
 import Collar from '../../../../test-app/app/models/Collar'
@@ -12,6 +13,39 @@ import PostComment from '../../../../test-app/app/models/PostComment'
 import User from '../../../../test-app/app/models/User'
 
 describe('Dream#associationQuery', () => {
+  context('with undefined passed in a where clause', () => {
+    it('raises an exception', async () => {
+      const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+      await expect(
+        async () => await user.associationQuery('pets', { name: undefined }).all()
+      ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+    })
+
+    context('when undefined is applied at the association level', () => {
+      context('where clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.associationQuery('invalidWherePostComments').all()
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+
+      context('whereNot clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.associationQuery('invalidWhereNotPostComments').all()
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+    })
+  })
+
   context('with a HasMany association', () => {
     it('returns a chainable query encapsulating that association', async () => {
       const otherUser = await User.create({ email: 'fred@frewd', password: 'howyadoin' })

--- a/spec/unit/dream/associations/destroyAssociation.spec.ts
+++ b/spec/unit/dream/associations/destroyAssociation.spec.ts
@@ -13,6 +13,7 @@ import Pet from '../../../../test-app/app/models/Pet'
 import Post from '../../../../test-app/app/models/Post'
 import Rating from '../../../../test-app/app/models/Rating'
 import User from '../../../../test-app/app/models/User'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 
 describe('Dream#destroyAssociation', () => {
   let hooksSpy: jest.SpyInstance
@@ -65,6 +66,39 @@ describe('Dream#destroyAssociation', () => {
       expect.toBeOneOf([expect.anything(), undefined, null])
     )
   }
+
+  context('with undefined passed in a where clause', () => {
+    it('raises an exception', async () => {
+      const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+      await expect(
+        async () => await user.destroyAssociation('pets', { where: { name: undefined } })
+      ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+    })
+
+    context('when undefined is applied at the association level', () => {
+      context('where clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.destroyAssociation('invalidWherePostComments')
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+
+      context('whereNot clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.destroyAssociation('invalidWhereNotPostComments')
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+    })
+  })
 
   context('cascade is false (it is true by default)', () => {
     it('skips cascade-destroying associations', async () => {

--- a/spec/unit/dream/associations/updateAssociation.spec.ts
+++ b/spec/unit/dream/associations/updateAssociation.spec.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 import MissingRequiredAssociationWhereClause from '../../../../src/exceptions/associations/missing-required-association-where-clause'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import ApplicationModel from '../../../../test-app/app/models/ApplicationModel'
 import Collar from '../../../../test-app/app/models/Collar'
 import Composition from '../../../../test-app/app/models/Composition'
@@ -9,6 +10,40 @@ import Pet from '../../../../test-app/app/models/Pet'
 import User from '../../../../test-app/app/models/User'
 
 describe('Dream#updateAssociation', () => {
+  context('with undefined passed in a where clause', () => {
+    it('raises an exception', async () => {
+      const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+      await expect(
+        async () =>
+          await user.updateAssociation('pets', { name: 'howyadoin' }, { where: { name: undefined } })
+      ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+    })
+
+    context('when undefined is applied at the association level', () => {
+      context('where clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.updateAssociation('invalidWherePostComments', { body: 'hello world' })
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+
+      context('whereNot clause has an undefined value', () => {
+        it('raises an exception', async () => {
+          const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+          const post = await user.createAssociation('posts')
+
+          await expect(
+            async () => await post.updateAssociation('invalidWhereNotPostComments', { body: 'hello world' })
+          ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+        })
+      })
+    })
+  })
+
   it('calls model hooks for each associated record', async () => {
     const user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
     const composition = await user.createAssociation('compositions')

--- a/spec/unit/dream/findBy.spec.ts
+++ b/spec/unit/dream/findBy.spec.ts
@@ -1,3 +1,4 @@
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import ApplicationModel from '../../../test-app/app/models/ApplicationModel'
 import Balloon from '../../../test-app/app/models/Balloon'
 import Latex from '../../../test-app/app/models/Balloon/Latex'
@@ -8,6 +9,14 @@ describe('Dream.findBy', () => {
     const u = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
     const user = await User.findBy({ id: u.id, email: 'fred@frewd' })
     expect(user!.email).toEqual('fred@frewd')
+  })
+
+  context('when passed undefined as a value', () => {
+    it('raises an exception', async () => {
+      await expect(async () => await User.findBy({ email: undefined })).rejects.toThrowError(
+        CannotPassUndefinedAsAValueToAWhereClause
+      )
+    })
   })
 
   context('STI model', () => {

--- a/spec/unit/query/findBy.spec.ts
+++ b/spec/unit/query/findBy.spec.ts
@@ -1,5 +1,6 @@
-import User from '../../../test-app/app/models/User'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import ops from '../../../src/ops'
+import User from '../../../test-app/app/models/User'
 
 describe('Query#findBy', () => {
   let user: User
@@ -10,6 +11,14 @@ describe('Query#findBy', () => {
   it('applies a where query and grabs first result', async () => {
     const reloadedUser = await User.query().findBy({ email: 'fred@frewd' })
     expect(reloadedUser).toMatchDreamModel(user)
+  })
+
+  context('when passed undefined as a value', () => {
+    it('raises an exception', async () => {
+      await expect(async () => await User.query().findBy({ email: undefined })).rejects.toThrowError(
+        CannotPassUndefinedAsAValueToAWhereClause
+      )
+    })
   })
 
   context('similarity operator is used', () => {

--- a/spec/unit/query/where.spec.ts
+++ b/spec/unit/query/where.spec.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 import { CalendarDate } from '../../../src'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import AnyRequiresArrayColumn from '../../../src/exceptions/ops/any-requires-array-column'
 import ScoreMustBeANormalNumber from '../../../src/exceptions/ops/score-must-be-a-normal-number'
 import range from '../../../src/helpers/range'
@@ -27,6 +28,14 @@ describe('Query#where', () => {
 
     const users = await User.where({ email: 'fred@frewd', name: 'Hello' }).all()
     expect(users).toMatchDreamModels([user1])
+  })
+
+  context('when passed undefined as a value', () => {
+    it('raises an exception', async () => {
+      await expect(async () => await User.query().where({ email: undefined }).all()).rejects.toThrowError(
+        CannotPassUndefinedAsAValueToAWhereClause
+      )
+    })
   })
 
   it('supports querying by CalendarDate', async () => {

--- a/spec/unit/query/whereAny.spec.ts
+++ b/spec/unit/query/whereAny.spec.ts
@@ -1,6 +1,18 @@
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import User from '../../../test-app/app/models/User'
 
 describe('Query#whereAny', () => {
+  context('when passed undefined as a value', () => {
+    it('raises an exception', async () => {
+      await expect(
+        async () =>
+          await User.query()
+            .whereAny([{ email: undefined }, { email: 'hi' }])
+            .all()
+      ).rejects.toThrowError(CannotPassUndefinedAsAValueToAWhereClause)
+    })
+  })
+
   context('within where-object', () => {
     it('treats keys within the object as AND statements', async () => {
       await User.create({ email: 'fred@frewd', password: 'howyadoin' })

--- a/spec/unit/query/whereNot.spec.ts
+++ b/spec/unit/query/whereNot.spec.ts
@@ -1,10 +1,19 @@
 import CannotNegateSimilarityClause from '../../../src/exceptions/cannot-negate-similarity-clause'
+import CannotPassUndefinedAsAValueToAWhereClause from '../../../src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import ops from '../../../src/ops'
 import Post from '../../../test-app/app/models/Post'
 import Rating from '../../../test-app/app/models/Rating'
 import User from '../../../test-app/app/models/User'
 
 describe('Query#whereNot', () => {
+  context('when passed undefined as a value', () => {
+    it('raises an exception', async () => {
+      await expect(async () => await User.query().whereNot({ email: undefined }).all()).rejects.toThrowError(
+        CannotPassUndefinedAsAValueToAWhereClause
+      )
+    })
+  })
+
   it('negates a query', async () => {
     await User.create({ email: 'fred@frewd', password: 'howyadoin' })
     const user2 = await User.create({ email: 'danny@nelso', password: 'howyadoin' })

--- a/src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause.ts
+++ b/src/exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause.ts
@@ -1,0 +1,19 @@
+import Dream from '../dream'
+
+export default class CannotPassUndefinedAsAValueToAWhereClause extends Error {
+  constructor(
+    private dreamClass: typeof Dream,
+    private key: string
+  ) {
+    super()
+  }
+
+  public get message() {
+    return `
+Cannot pass undefined as a value to a where clause.
+
+dream class: ${this.dreamClass.name}
+key receiving an undefined value: ${this.key}
+`
+  }
+}

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -48,6 +48,12 @@ export default class Post extends ApplicationModel {
   })
   public ratings: Rating[]
 
+  @Post.HasMany('PostComment', { where: { body: undefined } })
+  public invalidWherePostComments: PostComment[]
+
+  @Post.HasMany('PostComment', { whereNot: { body: undefined } })
+  public invalidWhereNotPostComments: PostComment[]
+
   // Traveling through NonNullRating, a model
   // which uses a default scope to automatically
   // exclude any Rating with a null body.

--- a/test-app/db/schema.ts
+++ b/test-app/db/schema.ts
@@ -2670,6 +2670,20 @@ export const schema = {
         optional: null,
         requiredWhereClauses: null,
       },
+      invalidWhereNotPostComments: {
+        type: 'HasMany',
+        foreignKey: 'postId',
+        tables: ['post_comments'],
+        optional: null,
+        requiredWhereClauses: null,
+      },
+      invalidWherePostComments: {
+        type: 'HasMany',
+        foreignKey: 'postId',
+        tables: ['post_comments'],
+        optional: null,
+        requiredWhereClauses: null,
+      },
       overriddenNonNullRatings: {
         type: 'HasMany',
         foreignKey: 'rateableId',


### PR DESCRIPTION
In javascript, it is considered valid to have an object whos keys are pointing to undefined values. Prior to this PR, we would simply filter out any keys which had undefined values. However, this could lead to completely unexpected consequences in the case where you are not anticipating that a value might be undefined, since providing undefined as a value would simply omit that field. This led to a terrible problem in a specific case for us, where we called `await User.findBy({ rvoId })`, not anticipating that if rvoId were undefined, that it would just find the first user in the db.

To protect against this easy mistake, this PR introduces new behavior for underlying where clauses, to detect and raise an exception when encountering an undefined value, rather than simply filtering it out.

close https://rvohealth.atlassian.net/browse/PDTC-6152