### PR TITLE
Update language in NoUpdateOnAssociationQuery error to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/associations/updateAssociation.spec.ts
+++ b/spec/unit/dream/associations/updateAssociation.spec.ts
@@ -10,6 +10,38 @@ import Pet from '../../../../test-app/app/models/Pet'
 import User from '../../../../test-app/app/models/User'
 
 describe('Dream#updateAssociation', () => {
+  context('with a where clause', () => {
+    it('limits the update to the where clause', async () => {
+      const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+      const aster = await Pet.create({ user, name: 'Aster', species: 'cat' })
+      const violet = await Pet.create({ user, name: 'Violet', species: 'frog' })
+
+      await user.updateAssociation('pets', { species: 'dog' }, { where: { id: violet.id } })
+
+      await aster.reload()
+      await violet.reload()
+
+      expect(aster.species).toEqual('cat')
+      expect(violet.species).toEqual('dog')
+    })
+
+    it('retains the association based limits', async () => {
+      const user1 = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+      const aster = await Pet.create({ user: user1, name: 'Aster', species: 'cat' })
+
+      const user2 = await User.create({ email: 'frewd@fred', password: 'howyadoin' })
+      const violet = await Pet.create({ user: user2, name: 'Violet', species: 'frog' })
+
+      await user1.updateAssociation('pets', { species: 'dog' }, { where: { id: violet.id } })
+
+      await aster.reload()
+      await violet.reload()
+
+      expect(aster.species).toEqual('cat')
+      expect(violet.species).toEqual('frog')
+    })
+  })
+
   context('with undefined passed in a where clause', () => {
     it('raises an exception', async () => {
       const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
@@ -69,7 +101,7 @@ describe('Dream#updateAssociation', () => {
   })
 
   context('with a HasMany association', () => {
-    it('updates the association', async () => {
+    it('updates the associated models', async () => {
       const otherUser = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
       await Composition.create({ user: otherUser })
 

--- a/spec/unit/query/update.spec.ts
+++ b/spec/unit/query/update.spec.ts
@@ -1,6 +1,6 @@
 import DreamDbConnection from '../../../src/db/dream-db-connection'
 import ReplicaSafe from '../../../src/decorators/replica-safe'
-import NoUpdateAllOnAssociationQuery from '../../../src/exceptions/no-updateall-on-association-query'
+import NoUpdateOnAssociationQuery from '../../../src/exceptions/no-update-on-association-query'
 import NoUpdateAllOnJoins from '../../../src/exceptions/no-updateall-on-joins'
 import ops from '../../../src/ops'
 import Pet from '../../../test-app/app/models/Pet'
@@ -57,7 +57,7 @@ describe('Query#update', () => {
       await user.createAssociation('compositions', { content: 'Opus' })
 
       await expect(user.associationQuery('compositions').update({ content: 'cool' })).rejects.toThrow(
-        NoUpdateAllOnAssociationQuery
+        NoUpdateOnAssociationQuery
       )
     })
   })

--- a/src/dream/query.ts
+++ b/src/dream/query.ts
@@ -45,7 +45,7 @@ import CannotNegateSimilarityClause from '../exceptions/cannot-negate-similarity
 import CannotPassAdditionalFieldsToPluckEachAfterCallback from '../exceptions/cannot-pass-additional-fields-to-pluck-each-after-callback-function'
 import CannotPassUndefinedAsAValueToAWhereClause from '../exceptions/cannot-pass-undefined-as-a-value-to-a-where-clause'
 import MissingRequiredCallbackFunctionToPluckEach from '../exceptions/missing-required-callback-function-to-pluck-each'
-import NoUpdateAllOnAssociationQuery from '../exceptions/no-updateall-on-association-query'
+import NoUpdateOnAssociationQuery from '../exceptions/no-update-on-association-query'
 import NoUpdateAllOnJoins from '../exceptions/no-updateall-on-joins'
 import RecordNotFound from '../exceptions/record-not-found'
 import CalendarDate from '../helpers/CalendarDate'
@@ -2478,7 +2478,7 @@ export default class Query<DreamInstance extends Dream> extends ConnectedToDB<Dr
     attributes: DreamTableSchema<DreamInstance>,
     { skipHooks }: { skipHooks?: boolean } = {}
   ) {
-    if (this.baseSelectQuery) throw new NoUpdateAllOnAssociationQuery()
+    if (this.baseSelectQuery) throw new NoUpdateOnAssociationQuery()
     if (Object.keys(this.innerJoinStatements).length) throw new NoUpdateAllOnJoins()
     if (Object.keys(this.leftJoinStatements).length) throw new NoUpdateAllOnJoins()
 

--- a/src/exceptions/no-update-on-association-query.ts
+++ b/src/exceptions/no-update-on-association-query.ts
@@ -1,0 +1,7 @@
+export default class NoUpdateOnAssociationQuery extends Error {
+  public get message() {
+    return `
+udpate may not be called on an associationQuery. Use updateAssociation instead.
+    `
+  }
+}

--- a/src/exceptions/no-updateall-on-association-query.ts
+++ b/src/exceptions/no-updateall-on-association-query.ts
@@ -1,7 +1,0 @@
-export default class NoUpdateAllOnAssociationQuery extends Error {
-  public get message() {
-    return `
-udpateAll may not be called on an associationQuery. Use associationUpdateQuery instead
-    `
-  }
-}


### PR DESCRIPTION
match current API.

Add spec to ensure where clauses on updateAssociation don't break out of the association-restricted models.