### PR TITLE
In most cases, it doesn't make sense for

### DIFF
--- a/spec/unit/cli/generateDreamContent.spec.ts
+++ b/spec/unit/cli/generateDreamContent.spec.ts
@@ -236,8 +236,8 @@ export default class Paper extends ApplicationModel {
       })
     })
 
-    context('relationships', () => {
-      context('when provided with a belongsTo relationship', () => {
+    context('associations', () => {
+      context('belongs_to', () => {
         it('generates a BelongsTo relationship in model', () => {
           const res = generateDreamContent({
             fullyQualifiedModelName: 'composition',
@@ -344,76 +344,6 @@ export default class CatToy extends ApplicationModel {
   @CatToy.BelongsTo('Pet/Domestic/Cat')
   public petDomesticCat: PetDomesticCat
   public petDomesticCatId: DreamColumn<CatToy, 'petDomesticCatId'>
-}
-`
-            )
-          })
-
-          it('can handle has many associations with nested paths', () => {
-            const res = generateDreamContent({
-              fullyQualifiedModelName: 'cat_toy',
-              columnsWithTypes: ['pet/domestic/cat:has_many'],
-              serializer: true,
-            })
-            expect(res).toEqual(
-              `\
-import { DreamColumn, DreamSerializers } from '@rvohealth/dream'
-import ApplicationModel from './ApplicationModel'
-import PetDomesticCat from './Pet/Domestic/Cat'
-
-export default class CatToy extends ApplicationModel {
-  public get table() {
-    return 'cat_toys' as const
-  }
-
-  public get serializers(): DreamSerializers<CatToy> {
-    return {
-      default: 'CatToySerializer',
-      summary: 'CatToySummarySerializer',
-    }
-  }
-
-  public id: DreamColumn<CatToy, 'id'>
-  public createdAt: DreamColumn<CatToy, 'createdAt'>
-  public updatedAt: DreamColumn<CatToy, 'updatedAt'>
-
-  @CatToy.HasMany('Pet/Domestic/Cat')
-  public petDomesticCats: PetDomesticCat[]
-}
-`
-            )
-          })
-
-          it('can handle has one associations with nested paths', () => {
-            const res = generateDreamContent({
-              fullyQualifiedModelName: 'cat_toy',
-              columnsWithTypes: ['pet/domestic/cat:has_one'],
-              serializer: true,
-            })
-            expect(res).toEqual(
-              `\
-import { DreamColumn, DreamSerializers } from '@rvohealth/dream'
-import ApplicationModel from './ApplicationModel'
-import PetDomesticCat from './Pet/Domestic/Cat'
-
-export default class CatToy extends ApplicationModel {
-  public get table() {
-    return 'cat_toys' as const
-  }
-
-  public get serializers(): DreamSerializers<CatToy> {
-    return {
-      default: 'CatToySerializer',
-      summary: 'CatToySummarySerializer',
-    }
-  }
-
-  public id: DreamColumn<CatToy, 'id'>
-  public createdAt: DreamColumn<CatToy, 'createdAt'>
-  public updatedAt: DreamColumn<CatToy, 'updatedAt'>
-
-  @CatToy.HasOne('Pet/Domestic/Cat')
-  public petDomesticCat: PetDomesticCat
 }
 `
             )
@@ -570,18 +500,17 @@ export default class Composition extends ApplicationModel {
         })
       })
 
-      context('when provided with a hasOne relationship', () => {
-        it('generates a HasOne relationship in model', () => {
+      context('has_one', () => {
+        it('is ignored', () => {
           const res = generateDreamContent({
             fullyQualifiedModelName: 'composition',
-            columnsWithTypes: ['user:has_one'],
+            columnsWithTypes: ['graph_node:has_one'],
             serializer: true,
           })
           expect(res).toEqual(
             `\
 import { DreamColumn, DreamSerializers } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import User from './User'
 
 export default class Composition extends ApplicationModel {
   public get table() {
@@ -598,64 +527,23 @@ export default class Composition extends ApplicationModel {
   public id: DreamColumn<Composition, 'id'>
   public createdAt: DreamColumn<Composition, 'createdAt'>
   public updatedAt: DreamColumn<Composition, 'updatedAt'>
-
-  @Composition.HasOne('User')
-  public user: User
 }
 `
           )
         })
       })
 
-      context('when provided with a hasMany relationship', () => {
-        it('generates a HasMany relationship in model', () => {
-          const res = generateDreamContent({
-            fullyQualifiedModelName: 'user',
-            columnsWithTypes: ['composition:has_many'],
-            serializer: true,
-          })
-          expect(res).toEqual(
-            `\
-import { DreamColumn, DreamSerializers } from '@rvohealth/dream'
-import ApplicationModel from './ApplicationModel'
-import Composition from './Composition'
-
-export default class User extends ApplicationModel {
-  public get table() {
-    return 'users' as const
-  }
-
-  public get serializers(): DreamSerializers<User> {
-    return {
-      default: 'UserSerializer',
-      summary: 'UserSummarySerializer',
-    }
-  }
-
-  public id: DreamColumn<User, 'id'>
-  public createdAt: DreamColumn<User, 'createdAt'>
-  public updatedAt: DreamColumn<User, 'updatedAt'>
-
-  @User.HasMany('Composition')
-  public compositions: Composition[]
-}
-`
-          )
-        })
-      })
-
-      context('when provided with a relationship and using uuids', () => {
-        it('generates a uuid id field for relations relationship in model', () => {
+      context('has_many', () => {
+        it('is ignored', () => {
           const res = generateDreamContent({
             fullyQualifiedModelName: 'composition',
-            columnsWithTypes: ['user:belongs_to'],
+            columnsWithTypes: ['graph_node:has_one'],
             serializer: true,
           })
           expect(res).toEqual(
             `\
 import { DreamColumn, DreamSerializers } from '@rvohealth/dream'
 import ApplicationModel from './ApplicationModel'
-import User from './User'
 
 export default class Composition extends ApplicationModel {
   public get table() {
@@ -672,10 +560,6 @@ export default class Composition extends ApplicationModel {
   public id: DreamColumn<Composition, 'id'>
   public createdAt: DreamColumn<Composition, 'createdAt'>
   public updatedAt: DreamColumn<Composition, 'updatedAt'>
-
-  @Composition.BelongsTo('User')
-  public user: User
-  public userId: DreamColumn<Composition, 'userId'>
 }
 `
           )

--- a/spec/unit/cli/generateSerializerContent.spec.ts
+++ b/spec/unit/cli/generateSerializerContent.spec.ts
@@ -234,8 +234,8 @@ export default class UserSerializer<
       })
 
       context('when one of those attributes is an association', () => {
-        context('BelongsTo', () => {
-          it('correctly injects RendersOne decorator and imports for the model', () => {
+        context('belongs_to', () => {
+          it('omits it from the attributes', () => {
             const res = generateSerializerContent({
               fullyQualifiedModelName: 'user',
               columnsWithTypes: ['organization:belongs_to'],
@@ -243,9 +243,8 @@ export default class UserSerializer<
 
             expect(res).toEqual(
               `\
-import { Attribute, DreamColumn, DreamSerializer, RendersOne } from '@rvohealth/dream'
+import { Attribute, DreamColumn, DreamSerializer } from '@rvohealth/dream'
 import User from '../models/User'
-import Organization from '../models/Organization'
 
 export class UserSummarySerializer<
   DataType extends User,
@@ -259,91 +258,23 @@ export default class UserSerializer<
   DataType extends User,
   Passthrough extends object,
 > extends UserSummarySerializer<DataType, Passthrough> {
-  @RendersOne(Organization)
-  public organization: Organization
-}
-`
-            )
-          })
-        })
 
-        context('HasOne', () => {
-          it('correctly injects RendersOne decorator and imports for the model', () => {
-            const res = generateSerializerContent({
-              fullyQualifiedModelName: 'User',
-              columnsWithTypes: ['Organization:has_one'],
-            })
-
-            expect(res).toEqual(
-              `\
-import { Attribute, DreamColumn, DreamSerializer, RendersOne } from '@rvohealth/dream'
-import User from '../models/User'
-import Organization from '../models/Organization'
-
-export class UserSummarySerializer<
-  DataType extends User,
-  Passthrough extends object,
-> extends DreamSerializer<DataType, Passthrough> {
-  @Attribute(User)
-  public id: DreamColumn<User, 'id'>
-}
-
-export default class UserSerializer<
-  DataType extends User,
-  Passthrough extends object,
-> extends UserSummarySerializer<DataType, Passthrough> {
-  @RendersOne(Organization)
-  public organization: Organization
-}
-`
-            )
-          })
-        })
-
-        context('HasMany', () => {
-          it('correctly injects RendersMany decorator and imports for the model', () => {
-            const res = generateSerializerContent({
-              fullyQualifiedModelName: 'User',
-              columnsWithTypes: ['Organization:has_many'],
-            })
-
-            expect(res).toEqual(
-              `\
-import { Attribute, DreamColumn, DreamSerializer, RendersMany } from '@rvohealth/dream'
-import User from '../models/User'
-import Organization from '../models/Organization'
-
-export class UserSummarySerializer<
-  DataType extends User,
-  Passthrough extends object,
-> extends DreamSerializer<DataType, Passthrough> {
-  @Attribute(User)
-  public id: DreamColumn<User, 'id'>
-}
-
-export default class UserSerializer<
-  DataType extends User,
-  Passthrough extends object,
-> extends UserSummarySerializer<DataType, Passthrough> {
-  @RendersMany(Organization)
-  public organizations: Organization[]
 }
 `
             )
           })
 
-          context('when passed an association that should not be pluralized', () => {
-            it('correctly injects RendersMany decorator and imports for the model', () => {
+          context('optional', () => {
+            it('omits it from the attributes', () => {
               const res = generateSerializerContent({
-                fullyQualifiedModelName: 'User',
-                columnsWithTypes: ['Paper:has_many'],
+                fullyQualifiedModelName: 'user',
+                columnsWithTypes: ['organization:belongs_to:optional'],
               })
 
               expect(res).toEqual(
                 `\
-import { Attribute, DreamColumn, DreamSerializer, RendersMany } from '@rvohealth/dream'
+import { Attribute, DreamColumn, DreamSerializer } from '@rvohealth/dream'
 import User from '../models/User'
-import Paper from '../models/Paper'
 
 export class UserSummarySerializer<
   DataType extends User,
@@ -357,8 +288,7 @@ export default class UserSerializer<
   DataType extends User,
   Passthrough extends object,
 > extends UserSummarySerializer<DataType, Passthrough> {
-  @RendersMany(Paper)
-  public paper: Paper[]
+
 }
 `
               )
@@ -366,33 +296,62 @@ export default class UserSerializer<
           })
         })
 
-        context('nested models', () => {
-          it('correctly injects decorator and imports for the model, accounting for nesting', () => {
+        context('has_one', () => {
+          it('omits it from the attributes', () => {
             const res = generateSerializerContent({
-              fullyQualifiedModelName: 'User/Admin',
-              columnsWithTypes: ['Double/Nested/MyModel:belongs_to'],
+              fullyQualifiedModelName: 'user',
+              columnsWithTypes: ['organization:has_one'],
             })
 
             expect(res).toEqual(
               `\
-import { Attribute, DreamColumn, DreamSerializer, RendersOne } from '@rvohealth/dream'
-import UserAdmin from '../../models/User/Admin'
-import DoubleNestedMyModel from '../../models/Double/Nested/MyModel'
+import { Attribute, DreamColumn, DreamSerializer } from '@rvohealth/dream'
+import User from '../models/User'
 
-export class UserAdminSummarySerializer<
-  DataType extends UserAdmin,
+export class UserSummarySerializer<
+  DataType extends User,
   Passthrough extends object,
 > extends DreamSerializer<DataType, Passthrough> {
-  @Attribute(UserAdmin)
-  public id: DreamColumn<UserAdmin, 'id'>
+  @Attribute(User)
+  public id: DreamColumn<User, 'id'>
 }
 
-export default class UserAdminSerializer<
-  DataType extends UserAdmin,
+export default class UserSerializer<
+  DataType extends User,
   Passthrough extends object,
-> extends UserAdminSummarySerializer<DataType, Passthrough> {
-  @RendersOne(DoubleNestedMyModel)
-  public doubleNestedMyModel: DoubleNestedMyModel
+> extends UserSummarySerializer<DataType, Passthrough> {
+
+}
+`
+            )
+          })
+        })
+
+        context('has_many', () => {
+          it('omits it from the attributes', () => {
+            const res = generateSerializerContent({
+              fullyQualifiedModelName: 'user',
+              columnsWithTypes: ['organization:has_many'],
+            })
+
+            expect(res).toEqual(
+              `\
+import { Attribute, DreamColumn, DreamSerializer } from '@rvohealth/dream'
+import User from '../models/User'
+
+export class UserSummarySerializer<
+  DataType extends User,
+  Passthrough extends object,
+> extends DreamSerializer<DataType, Passthrough> {
+  @Attribute(User)
+  public id: DreamColumn<User, 'id'>
+}
+
+export default class UserSerializer<
+  DataType extends User,
+  Passthrough extends object,
+> extends UserSummarySerializer<DataType, Passthrough> {
+
 }
 `
             )

--- a/src/helpers/cli/generateDreamContent.ts
+++ b/src/helpers/cli/generateDreamContent.ts
@@ -59,18 +59,8 @@ public ${associationName}Id: DreamColumn<${modelClassName}, '${associationName}I
 `
 
       case 'has_one':
-        modelImportStatements.push(associationImportStatement)
-        return `
-@${modelClassName}.HasOne('${fullyQualifiedAssociatedModelName}')
-public ${associationName}: ${associationModelName}
-`
-
       case 'has_many':
-        modelImportStatements.push(associationImportStatement)
-        return `
-@${modelClassName}.HasMany('${fullyQualifiedAssociatedModelName}')
-public ${pluralize(associationName)}: ${associationModelName}[]
-`
+        return ''
 
       case 'encrypted':
         dreamImports.push('Encrypted')

--- a/src/helpers/cli/generateSerializerContent.ts
+++ b/src/helpers/cli/generateSerializerContent.ts
@@ -1,4 +1,3 @@
-import pluralize from 'pluralize'
 import camelize from '../camelize'
 import globalClassNameFromFullyQualifiedModelName from '../globalClassNameFromFullyQualifiedModelName'
 import pascalize from '../pascalize'
@@ -62,21 +61,20 @@ export default function generateSerializerContent({
       )
     : 'DreamSerializer'
 
-  if (columnsWithTypes.find(attr => /:belongs_to|:has_one/.test(attr))) dreamImports.push('RendersOne')
-  if (columnsWithTypes.find(attr => /:has_many/.test(attr))) dreamImports.push('RendersMany')
-
   const additionalModelImports: string[] = []
   columnsWithTypes.forEach(attr => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [name, type] = attr.split(':')
-    if (['belongs_to', 'has_one', 'has_many'].includes(type)) {
-      const fullyQualifiedAssociatedModelName = standardizeFullyQualifiedModelName(name)
 
-      additionalModelImports.push(
-        importStatementForModel(fullyQualifiedModelName, fullyQualifiedAssociatedModelName)
-      )
-    } else {
-      dreamImports.push('Attribute')
-      dreamImports.push('DreamColumn')
+    switch (type) {
+      case 'belongs_to':
+      case 'has_one':
+      case 'has_many':
+        break
+
+      default:
+        dreamImports.push('Attribute')
+        dreamImports.push('DreamColumn')
     }
   })
 
@@ -110,12 +108,8 @@ ${columnsWithTypes
     switch (type) {
       case 'belongs_to':
       case 'has_one':
-        return `  @RendersOne(${associatedModelName})
-  public ${propertyName}: ${associatedModelName}`
-
       case 'has_many':
-        return `  @RendersMany(${associatedModelName})
-  public ${pluralize(propertyName)}: ${associatedModelName}[]`
+        return ''
 
       default:
         return `  @Attribute(${modelClassName}${attributeOptionsSpecifier(type, attr)})


### PR DESCRIPTION
a model to render a model it belongs-to.
Instead, a model will render things it
has-one or has-many of. So don't add
RendersOne to serializers when generating
a model with a belongs-to association.

Ignore has_one and has_many options when
generating models because the foreign key
is on the model that belongs-to, so models
that will have has_one/many need to be
created first, and won't be able to import
the model that doesn't yet exist.