### PR TITLE
When creating a polymorphic model using

### DIFF
--- a/spec/unit/cli/generateFactoryContent.spec.ts
+++ b/spec/unit/cli/generateFactoryContent.spec.ts
@@ -45,6 +45,28 @@ export default async function createPost(attrs: UpdateableProperties<Post> = {})
 `
       )
     })
+
+    context('that end with "_type"', () => {
+      it('omits the default', () => {
+        const res = generateFactoryContent({
+          fullyQualifiedModelName: 'Post',
+          columnsWithTypes: [
+            'localizable_id:bigint',
+            'localizable_type:enum:localized_types:Host,Place,Room',
+          ],
+        })
+        expect(res).toEqual(
+          `\
+import { UpdateableProperties } from '@rvohealth/dream'
+import Post from '../../app/models/Post'
+
+export default async function createPost(attrs: UpdateableProperties<Post> = {}) {
+  return await Post.create(attrs)
+}
+`
+        )
+      })
+    })
   })
 
   context('with a nested name', () => {

--- a/src/helpers/cli/generateFactoryContent.ts
+++ b/src/helpers/cli/generateFactoryContent.ts
@@ -28,6 +28,8 @@ export default function generateFactoryContent({
     const associationFactoryImportStatement = `import create${associationModelName} from '${relativeDreamPath('factories', 'factories', fullyQualifiedModelName, fullyQualifiedAssociatedModelName)}'`
     const associationName = camelize(associationModelName)
 
+    if (/_type$/.test(attributeName)) continue
+
     if (!attributeType)
       throw new Error(
         `Must pass a column type for ${fullyQualifiedAssociatedModelName} (i.e. ${fullyQualifiedAssociatedModelName}:string)`


### PR DESCRIPTION
a generated model factory, we may pass
an associated model. Providing a default
value for this column overrides that,
which can cause the specs to fail
in a confusing way.