### PR TITLE
`find` and `findOrFail` accept `null` and `undefined`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/find.spec.ts
+++ b/spec/unit/dream/find.spec.ts
@@ -16,13 +16,13 @@ describe('Dream.find', () => {
 
   context('when passed undefined', () => {
     it('returns null', async () => {
-      expect(await User.find(undefined as any)).toBeNull()
+      expect(await User.find(undefined)).toBeNull()
     })
   })
 
   context('when passed null', () => {
     it('returns null', async () => {
-      expect(await User.find(null as any)).toBeNull()
+      expect(await User.find(null)).toBeNull()
     })
   })
 
@@ -44,6 +44,22 @@ describe('Dream.find', () => {
     it('can find records', async () => {
       await ApplicationModel.transaction(async txn => {
         expect(await User.txn(txn).find(user.id)).toMatchDreamModel(user)
+      })
+    })
+
+    context('when passed undefined', () => {
+      it('returns null', async () => {
+        await ApplicationModel.transaction(async txn => {
+          expect(await User.txn(txn).find(undefined)).toBeNull()
+        })
+      })
+    })
+
+    context('when passed null', () => {
+      it('returns null', async () => {
+        await ApplicationModel.transaction(async txn => {
+          expect(await User.txn(txn).find(null)).toBeNull()
+        })
       })
     })
   })

--- a/spec/unit/dream/findOrFail.spec.ts
+++ b/spec/unit/dream/findOrFail.spec.ts
@@ -47,5 +47,29 @@ describe('Dream.findOrFail', () => {
         expect(await User.txn(txn).findOrFail(user.id)).toMatchDreamModel(user)
       })
     })
+
+    context('when no record is found', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.txn(txn).findOrFail(0)).rejects.toThrow(RecordNotFound)
+        })
+      })
+    })
+
+    context('when passed undefined', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.txn(txn).findOrFail(undefined)).rejects.toThrow(RecordNotFound)
+        })
+      })
+    })
+
+    context('when passed null', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.txn(txn).findOrFail(null)).rejects.toThrow(RecordNotFound)
+        })
+      })
+    })
   })
 })

--- a/spec/unit/query/find.spec.ts
+++ b/spec/unit/query/find.spec.ts
@@ -1,5 +1,6 @@
-import User from '../../../test-app/app/models/User'
 import ops from '../../../src/ops'
+import ApplicationModel from '../../../test-app/app/models/ApplicationModel'
+import User from '../../../test-app/app/models/User'
 
 describe('Query#find', () => {
   let user: User
@@ -15,13 +16,13 @@ describe('Query#find', () => {
 
   context('when passed undefined', () => {
     it('returns null', async () => {
-      expect(await User.query().find(undefined as any)).toBeNull()
+      expect(await User.query().find(undefined)).toBeNull()
     })
   })
 
   context('when passed null', () => {
     it('returns null', async () => {
-      expect(await User.query().find(null as any)).toBeNull()
+      expect(await User.query().find(null)).toBeNull()
     })
   })
 
@@ -43,6 +44,30 @@ describe('Query#find', () => {
           .where({ name: ops.similarity('nonmatch') })
           .find(user.id)
       ).toBeNull()
+    })
+  })
+
+  context('when passed a transaction', () => {
+    it('can find records', async () => {
+      await ApplicationModel.transaction(async txn => {
+        expect(await User.query().txn(txn).find(user.id)).toMatchDreamModel(user)
+      })
+    })
+
+    context('when passed undefined', () => {
+      it('returns null', async () => {
+        await ApplicationModel.transaction(async txn => {
+          expect(await User.query().txn(txn).find(undefined)).toBeNull()
+        })
+      })
+    })
+
+    context('when passed null', () => {
+      it('returns null', async () => {
+        await ApplicationModel.transaction(async txn => {
+          expect(await User.query().txn(txn).find(null)).toBeNull()
+        })
+      })
     })
   })
 })

--- a/spec/unit/query/findOrFail.spec.ts
+++ b/spec/unit/query/findOrFail.spec.ts
@@ -1,5 +1,6 @@
 import RecordNotFound from '../../../src/exceptions/RecordNotFound'
 import ops from '../../../src/ops'
+import ApplicationModel from '../../../test-app/app/models/ApplicationModel'
 import User from '../../../test-app/app/models/User'
 
 describe('Query#findOrFail', () => {
@@ -16,7 +17,7 @@ describe('Query#findOrFail', () => {
 
   context('when passed undefined', () => {
     it('raises an exception', async () => {
-      await expect(User.query().findOrFail(undefined as any)).rejects.toThrow(RecordNotFound)
+      await expect(User.query().findOrFail(undefined)).rejects.toThrow(RecordNotFound)
     })
   })
 
@@ -46,6 +47,38 @@ describe('Query#findOrFail', () => {
           .where({ name: ops.similarity('nonmatch') })
           .findOrFail(user.id)
       ).rejects.toThrow(RecordNotFound)
+    })
+  })
+
+  context('when passed a transaction', () => {
+    it('can find records', async () => {
+      await ApplicationModel.transaction(async txn => {
+        expect(await User.query().txn(txn).findOrFail(user.id)).toMatchDreamModel(user)
+      })
+    })
+
+    context('when no record is found', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.query().txn(txn).findOrFail(0)).rejects.toThrow(RecordNotFound)
+        })
+      })
+    })
+
+    context('when passed undefined', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.query().txn(txn).findOrFail(undefined)).rejects.toThrow(RecordNotFound)
+        })
+      })
+    })
+
+    context('when passed null', () => {
+      it('raises an exception', async () => {
+        await ApplicationModel.transaction(async txn => {
+          await expect(User.query().txn(txn).findOrFail(null)).rejects.toThrow(RecordNotFound)
+        })
+      })
     })
   })
 })

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -100,6 +100,7 @@ import {
   NextPreloadArgumentType,
   OrderDir,
   PassthroughColumnNames,
+  PrimaryKeyForFind,
   SortableOptions,
   TableColumnNames,
   TableColumnType,
@@ -1257,15 +1258,9 @@ export default class Dream {
    * @param primaryKey - The primaryKey of the record to look up
    * @returns Either the found record, or else null
    */
-  public static async find<
-    T extends typeof Dream,
-    I extends InstanceType<T>,
-    Schema extends I['schema'],
-    TableName extends keyof Schema = I['table'] & keyof Schema,
-  >(
+  public static async find<T extends typeof Dream, I extends InstanceType<T>>(
     this: T,
-    primaryKey: Schema[TableName]['columns'][I['primaryKey'] &
-      keyof Schema[TableName]['columns']]['coercedType']
+    primaryKey: PrimaryKeyForFind<I>
   ): Promise<InstanceType<T> | null> {
     return await this.query().find(primaryKey)
   }
@@ -1282,12 +1277,10 @@ export default class Dream {
    * @param primaryKey - The primaryKey of the record to look up
    * @returns Either the found record, or else null
    */
-  public static async findOrFail<
-    T extends typeof Dream,
-    I extends InstanceType<T>,
-    Schema extends I['schema'],
-    SchemaIdType = Schema[InstanceType<T>['table']]['columns'][I['primaryKey']]['coercedType'],
-  >(this: T, primaryKey: SchemaIdType): Promise<InstanceType<T>> {
+  public static async findOrFail<T extends typeof Dream, I extends InstanceType<T>>(
+    this: T,
+    primaryKey: PrimaryKeyForFind<I>
+  ): Promise<InstanceType<T>> {
     return await this.query().findOrFail(primaryKey)
   }
 

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -10,6 +10,7 @@ import {
   DreamColumnNames,
   OrderDir,
   PassthroughColumnNames,
+  PrimaryKeyForFind,
   UpdateableProperties,
   VariadicJoinsArgs,
   VariadicLeftJoinLoadArgs,
@@ -174,14 +175,11 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
    * @param primaryKey - The primaryKey of the record to look up
    * @returns Either the found record, or else null
    */
-  public async find<
-    I extends DreamClassTransactionBuilder<DreamInstance>,
-    Schema extends DreamInstance['schema'],
-    SchemaIdType = Schema[DreamInstance['table']]['columns'][DreamInstance['primaryKey']]['coercedType'],
-  >(this: I, id: SchemaIdType): Promise<DreamInstance | null> {
-    return await this.queryInstance()
-      .where({ [this.dreamInstance.primaryKey]: id } as any)
-      .first()
+  public async find<I extends DreamClassTransactionBuilder<DreamInstance>>(
+    this: I,
+    id: PrimaryKeyForFind<DreamInstance>
+  ): Promise<DreamInstance | null> {
+    return await this.queryInstance().find(id)
   }
 
   /**
@@ -198,11 +196,10 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
    * @param primaryKey - The primaryKey of the record to look up
    * @returns The found record
    */
-  public async findOrFail<
-    I extends DreamClassTransactionBuilder<DreamInstance>,
-    Schema extends DreamInstance['schema'],
-    SchemaIdType = Schema[DreamInstance['table']]['columns'][DreamInstance['primaryKey']]['coercedType'],
-  >(this: I, primaryKey: SchemaIdType): Promise<DreamInstance> {
+  public async findOrFail<I extends DreamClassTransactionBuilder<DreamInstance>>(
+    this: I,
+    primaryKey: PrimaryKeyForFind<DreamInstance>
+  ): Promise<DreamInstance> {
     return await this.queryInstance().findOrFail(primaryKey)
   }
 
@@ -225,9 +222,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     this: I,
     attributes: Updateable<DB[DreamInstance['table']]>
   ): Promise<DreamInstance | null> {
-    return await this.queryInstance()
-      .where(attributes as any)
-      .first()
+    return await this.queryInstance().findBy(attributes as any)
   }
 
   /**

--- a/src/dream/Query.ts
+++ b/src/dream/Query.ts
@@ -84,6 +84,7 @@ import {
   IdType,
   OrderDir,
   PassthroughColumnNames,
+  PrimaryKeyForFind,
   RelaxedJoinStatement,
   RelaxedJoinWhereStatement,
   RelaxedPreloadStatement,
@@ -500,13 +501,7 @@ export default class Query<DreamInstance extends Dream> extends ConnectedToDB<Dr
    * @param primaryKey - The primaryKey of the record to look up
    * @returns Either the found record, or else null
    */
-  public async find<
-    Schema extends DreamInstance['schema'],
-    TableName extends keyof Schema = DreamInstance['table'] & keyof Schema,
-  >(
-    primaryKey: Schema[TableName]['columns'][DreamInstance['primaryKey'] &
-      keyof Schema[TableName]['columns']]['coercedType']
-  ): Promise<DreamInstance | null> {
+  public async find(primaryKey: PrimaryKeyForFind<DreamInstance>): Promise<DreamInstance | null> {
     if (!primaryKey) return null
 
     return await this.where({
@@ -527,13 +522,7 @@ export default class Query<DreamInstance extends Dream> extends ConnectedToDB<Dr
    * @param primaryKey - The primaryKey of the record to look up
    * @returns The found record
    */
-  public async findOrFail<
-    Schema extends DreamInstance['schema'],
-    TableName extends keyof Schema = DreamInstance['table'] & keyof Schema,
-  >(
-    primaryKey: Schema[TableName]['columns'][DreamInstance['primaryKey'] &
-      keyof Schema[TableName]['columns']]['coercedType']
-  ): Promise<DreamInstance> {
+  public async findOrFail(primaryKey: PrimaryKeyForFind<DreamInstance>): Promise<DreamInstance> {
     const record = await this.find(primaryKey)
     if (!record) throw new RecordNotFound(this.dreamInstance.constructor.name)
     return record

--- a/src/dream/types.ts
+++ b/src/dream/types.ts
@@ -54,6 +54,15 @@ export interface SortableOptions<T extends typeof Dream> {
     | (keyof DreamBelongsToAssociationMetadata<InstanceType<T>> | DreamColumnNames<InstanceType<T>>)[]
 }
 
+export type PrimaryKeyForFind<
+  I extends Dream,
+  Schema extends I['schema'] = I['schema'],
+  TableName extends keyof Schema = I['table'] & keyof Schema,
+> =
+  | Schema[TableName]['columns'][I['primaryKey'] & keyof Schema[TableName]['columns']]['coercedType']
+  | null
+  | undefined
+
 export type DreamColumnNames<
   DreamInstance extends Dream,
   DB = DreamInstance['DB'],


### PR DESCRIPTION
This avoids unnecessary guards when using these methods and is consistent with `findBy` and `findOrFailBy`

Also DRY up types and add missing specs