### PR TITLE
Queries built on associationQuery were not leveraging

### DIFF
--- a/spec/unit/dream/replicaSafe-specific-specs.spec.ts
+++ b/spec/unit/dream/replicaSafe-specific-specs.spec.ts
@@ -1,0 +1,108 @@
+import { CamelCasePlugin, Kysely, PostgresDialect, sql } from 'kysely'
+import { Pool } from 'pg'
+import db from '../../../src/db'
+import ConnectionConfRetriever from '../../../src/db/ConnectionConfRetriever'
+import DreamDbConnection from '../../../src/db/DreamDbConnection'
+import { DbConnectionType } from '../../../src/db/types'
+import User from '../../../test-app/app/models/User'
+
+/**
+ * NOTE: for our replica safe specs, we use a database that is not actually set up
+ * as a replica so that we can simulate situations in which data has been written
+ * to the primary database, but not yet propagated to the read replica.
+ *
+ * IMPORTANT: since our specs only set up one fake replica database (not one for
+ * every parallel spec database), it is important that _all_ specs that leverage
+ * the fake replica database are included in this one file (not spread out to other
+ * files since then it would be possible for two specs running in parallel to be
+ * modifying the one fake replica database)
+ */
+describe('replicaSafe specific specs', () => {
+  let fakeReplicaConnection: Kysely<unknown>
+
+  beforeEach(async () => {
+    const originalPrimaryConnection = DreamDbConnection.getConnection('primary')
+    const connectionConf = new ConnectionConfRetriever().getConnectionConf('primary')
+
+    const fakeReplicaName = `replica_test_${connectionConf.name}`
+    fakeReplicaConnection = new Kysely<unknown>({
+      dialect: new PostgresDialect({
+        pool: new Pool({
+          user: connectionConf.user || '',
+          password: connectionConf.password || '',
+          database: fakeReplicaName,
+          host: connectionConf.host || 'localhost',
+          port: connectionConf.port || 5432,
+          ssl: false,
+        }),
+      }),
+
+      plugins: [new CamelCasePlugin({ underscoreBetweenUppercaseLetters: true })],
+    })
+
+    jest
+      .spyOn(DreamDbConnection, 'getConnection')
+      .mockImplementation((connectionType: DbConnectionType) =>
+        connectionType === 'replica' ? fakeReplicaConnection : originalPrimaryConnection
+      )
+
+    // Spec suite truncation does not hit the fake replica database, so delete all data explicitly
+    await sql`DELETE FROM users;`.execute(db('replica'))
+    await sql`DELETE FROM posts;`.execute(db('replica'))
+    // end: Spec suite truncation does not hit the fake replica database, so delete all data explicitly
+
+    const resetUserSequenceSql = sql`ALTER SEQUENCE users_id_seq RESTART 1;`
+    const resetPostsSequenceSql = sql`ALTER SEQUENCE posts_id_seq RESTART 1;`
+    const userSql = sql`INSERT INTO users (email, password_digest, created_at, updated_at) VALUES ('fred@frewd.com', 'xxxxxxxxxxxxxxxx', '2025-01-13', '2025-01-13');`
+
+    await resetUserSequenceSql.execute(db('primary'))
+    await resetPostsSequenceSql.execute(db('primary'))
+    await userSql.execute(db('primary'))
+    await sql`INSERT INTO posts (user_id, body, created_at, updated_at) VALUES ('1', 'primary body', '2025-01-13', '2025-01-13');`.execute(
+      db('primary')
+    )
+
+    await resetUserSequenceSql.execute(db('replica'))
+    await resetPostsSequenceSql.execute(db('replica'))
+    await userSql.execute(db('replica'))
+    await sql`INSERT INTO posts (user_id, body, created_at, updated_at) VALUES ('1', 'replica body', '2025-01-13', '2025-01-13');`.execute(
+      db('replica')
+    )
+  })
+
+  afterEach(async () => {
+    await fakeReplicaConnection.destroy()
+  })
+
+  describe('Dream#associationQuery', () => {
+    it('queries the replica database', async () => {
+      const user = await User.findOrFail(1)
+
+      const primaryPost = await user.associationQuery('posts').firstOrFail()
+      expect(primaryPost.body).toEqual('primary body')
+
+      const replicaPost = await user.associationQuery('posts').connection('replica').firstOrFail()
+      expect(replicaPost.body).toEqual('replica body')
+    })
+  })
+
+  describe('Dream.preload', () => {
+    it('queries the replica database', async () => {
+      const primaryUser = await User.preload('posts').firstOrFail()
+      const replicaUser = await User.preload('posts').connection('replica').firstOrFail()
+
+      expect(primaryUser.posts[0].body).toEqual('primary body')
+      expect(replicaUser.posts[0].body).toEqual('replica body')
+    })
+  })
+
+  describe('Dream.leftJoinPreload', () => {
+    it('queries the replica database', async () => {
+      const primaryUser = await User.leftJoinPreload('posts').firstOrFail()
+      const replicaUser = await User.leftJoinPreload('posts').connection('replica').firstOrFail()
+
+      expect(primaryUser.posts[0].body).toEqual('primary body')
+      expect(replicaUser.posts[0].body).toEqual('replica body')
+    })
+  })
+})

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -114,6 +114,13 @@ export default class DreamBin {
     const dbConf = connectionRetriever.getConnectionConf('primary')
     const client = await loadPgClient({ useSystemDb: true })
 
+    if (process.env.DREAM_CORE_DEVELOPMENT === '1') {
+      const replicaTestWorkerDatabaseName = `replica_test_${dbConf.name}`
+      console.log(`creating fake replica test database ${replicaTestWorkerDatabaseName}`)
+      await client.query(`DROP DATABASE IF EXISTS ${replicaTestWorkerDatabaseName};`)
+      await client.query(`CREATE DATABASE ${replicaTestWorkerDatabaseName} TEMPLATE ${dbConf.name};`)
+    }
+
     for (let i = 2; i <= parallelTests; i++) {
       const workerDatabaseName = `${dbConf.name}_${i}`
 

--- a/src/dream-application/index.ts
+++ b/src/dream-application/index.ts
@@ -2,6 +2,7 @@ import { CompiledQuery } from 'kysely'
 import { Settings } from 'luxon'
 import { types as pgTypes } from 'pg'
 import db from '../db'
+import validateTable from '../db/validators/validateTable'
 import Dream from '../Dream'
 import { primaryKeyTypes } from '../dream/types'
 import Encrypt, { EncryptAlgorithm, EncryptOptions } from '../encrypt'
@@ -21,7 +22,6 @@ import { cacheDreamApplication, getCachedDreamApplicationOrFail } from './cache'
 import loadModels, { getModelsOrFail } from './helpers/loadModels'
 import loadSerializers, { getSerializersOrFail, setCachedSerializers } from './helpers/loadSerializers'
 import loadServices, { getServicesOrFail, setCachedServices } from './helpers/loadServices'
-import validateTable from '../db/validators/validateTable'
 
 // this needs to be done top-level to ensure proper configuration
 Settings.defaultZone = 'UTC'
@@ -199,7 +199,7 @@ Try setting it to something valid, like:
 
   private _parallelTests: number | undefined
   public get parallelTests() {
-    return this._parallelTests
+    return process.env.NODE_ENV === 'test' ? this._parallelTests : undefined
   }
 
   private _primaryKeyType: (typeof primaryKeyTypes)[number] = 'bigserial'

--- a/src/dream/Query.ts
+++ b/src/dream/Query.ts
@@ -4019,7 +4019,11 @@ export default class Query<DreamInstance extends Dream> extends ConnectedToDB<Dr
     let kyselyQuery: SelectQueryBuilder<any, any, any>
 
     if (this.baseSelectQuery) {
-      kyselyQuery = this.baseSelectQuery.buildSelect({ bypassSelectAll: true })
+      kyselyQuery = (
+        this.connectionOverride
+          ? this.baseSelectQuery.connection(this.connectionOverride)
+          : this.baseSelectQuery
+      ).buildSelect({ bypassSelectAll: true })
     } else {
       const from =
         this.baseSqlAlias === this.dreamClass.table

--- a/src/helpers/db/dropDb.ts
+++ b/src/helpers/db/dropDb.ts
@@ -29,6 +29,12 @@ async function maybeDropDuplicateDatabases(client: Client, dbName: string) {
   const parallelTests = DreamApplication.getOrFail().parallelTests
   if (!parallelTests) return
 
+  if (process.env.DREAM_CORE_DEVELOPMENT === '1') {
+    const replicaTestWorkerDatabaseName = `replica_test_${dbName}`
+    console.log(`dropping fake replica test database ${replicaTestWorkerDatabaseName}`)
+    await client.query(`DROP DATABASE IF EXISTS ${replicaTestWorkerDatabaseName};`)
+  }
+
   for (let i = 2; i <= parallelTests; i++) {
     const workerDatabaseName = `${dbName}_${i}`
     console.log(`dropping duplicate test database ${workerDatabaseName}`)


### PR DESCRIPTION
the replica connection when it was explicitly specified