### PR TITLE
Type protection against mixing preload and leftJoinPreload

### DIFF
--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -70,6 +70,7 @@ import {
   undestroyOptions,
 } from './dream/internal/destroyOptions'
 import ensureSTITypeFieldIsSet from './dream/internal/ensureSTITypeFieldIsSet'
+import extractAssociationMetadataFromAssociationName from './dream/internal/extractAssociationMetadataFromAssociationName'
 import reload from './dream/internal/reload'
 import runValidations from './dream/internal/runValidations'
 import saveDream from './dream/internal/saveDream'
@@ -86,6 +87,7 @@ import Query, {
   DefaultQueryTypeOptions,
   FindEachOpts,
   QueryWithJoinedAssociationsType,
+  QueryWithJoinedAssociationsTypeAndNoPreload,
 } from './dream/Query'
 import {
   AllDefaultScopeNames,
@@ -135,7 +137,6 @@ import cachedTypeForAttribute from './helpers/db/cachedTypeForAttribute'
 import isJsonColumn from './helpers/db/types/isJsonColumn'
 import inferSerializerFromDreamOrViewModel from './helpers/inferSerializerFromDreamOrViewModel'
 import { isString } from './helpers/typechecks'
-import extractAssociationMetadataFromAssociationName from './dream/internal/extractAssociationMetadataFromAssociationName'
 
 export default class Dream {
   public DB: any
@@ -1492,8 +1493,10 @@ export default class Dream {
     const Arr extends readonly unknown[],
     LastArg extends VariadicLeftJoinLoadArgs<DB, Schema, TableName, Arr>,
   >(this: T, ...args: [...Arr, LastArg]) {
-    return this.query().leftJoinPreload(...(args as any)) as QueryWithJoinedAssociationsType<
-      I,
+    return this.query().leftJoinPreload(
+      ...(args as any)
+    ) as unknown as QueryWithJoinedAssociationsTypeAndNoPreload<
+      Query<I>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -1549,7 +1552,7 @@ export default class Dream {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: T, ...args: [...Arr, LastArg]) {
     return this.query().innerJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      I,
+      Query<I>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -1574,7 +1577,7 @@ export default class Dream {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.query().innerJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      I,
+      Query<I>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -1600,7 +1603,7 @@ export default class Dream {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: T, ...args: [...Arr, LastArg]) {
     return this.query().leftJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      I,
+      Query<I>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -1625,7 +1628,7 @@ export default class Dream {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.query().leftJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      I,
+      Query<I>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }

--- a/src/decorators/SoftDelete.ts
+++ b/src/decorators/SoftDelete.ts
@@ -48,7 +48,7 @@ export default function SoftDelete(): ClassDecorator {
 
     dreamClass['softDelete'] = true
 
-    target[SOFT_DELETE_SCOPE_NAME] = function (query: Query<any>) {
+    target[SOFT_DELETE_SCOPE_NAME] = function (query: Query<any, any>) {
       return query.where({ [dreamClass.prototype.deletedAtField]: null } as any)
     }
 

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -6,9 +6,9 @@ import DreamTransaction from './DreamTransaction'
 import saveDream from './internal/saveDream'
 import Query, {
   BaseModelColumnTypes,
-  DefaultQueryTypeOptions,
   FindEachOpts,
   QueryWithJoinedAssociationsType,
+  QueryWithJoinedAssociationsTypeAndNoPreload,
 } from './Query'
 import {
   DefaultScopeName,
@@ -88,7 +88,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
   public limit<I extends DreamClassTransactionBuilder<DreamInstance>>(
     this: I,
     limit: number | null
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  ): Query<DreamInstance> {
     return this.queryInstance().limit(limit)
   }
 
@@ -108,7 +108,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
   public offset<I extends DreamClassTransactionBuilder<DreamInstance>>(
     this: I,
     offset: number | null
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  ): Query<DreamInstance> {
     return this.queryInstance().offset(offset)
   }
 
@@ -380,8 +380,10 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     const Arr extends readonly unknown[],
     LastArg extends VariadicLeftJoinLoadArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
-    return this.queryInstance().leftJoinPreload(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+    return this.queryInstance().leftJoinPreload(
+      ...(args as any)
+    ) as QueryWithJoinedAssociationsTypeAndNoPreload<
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -439,7 +441,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.queryInstance().innerJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -466,7 +468,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.queryInstance().leftJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -483,12 +485,8 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
    *
    * @returns A new Query instance
    */
-  public queryInstance<I extends DreamClassTransactionBuilder<DreamInstance>>(
-    this: I
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
-    return new Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>>(this.dreamInstance).txn(
-      this.dreamTransaction
-    )
+  public queryInstance<I extends DreamClassTransactionBuilder<DreamInstance>>(this: I): Query<DreamInstance> {
+    return new Query<DreamInstance>(this.dreamInstance).txn(this.dreamTransaction)
   }
 
   /**
@@ -498,7 +496,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
    */
   public removeAllDefaultScopes<I extends DreamClassTransactionBuilder<DreamInstance>>(
     this: I
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  ): Query<DreamInstance> {
     return this.queryInstance().removeAllDefaultScopes()
   }
 
@@ -511,7 +509,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
   public removeDefaultScope<I extends DreamClassTransactionBuilder<DreamInstance>>(
     this: I,
     scopeName: DefaultScopeName<DreamInstance>
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  ): Query<DreamInstance> {
     return this.queryInstance().removeDefaultScope(scopeName)
   }
 
@@ -694,10 +692,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
   public passthrough<
     I extends DreamClassTransactionBuilder<DreamInstance>,
     PassthroughColumns extends PassthroughColumnNames<DreamInstance>,
-  >(
-    this: I,
-    passthroughWhereStatement: PassthroughOnClause<PassthroughColumns>
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  >(this: I, passthroughWhereStatement: PassthroughOnClause<PassthroughColumns>): Query<DreamInstance> {
     return this.queryInstance().passthrough(passthroughWhereStatement as any)
   }
 
@@ -720,10 +715,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     DB extends DreamInstance['DB'],
     Schema extends DreamInstance['schema'],
     TableName extends AssociationTableNames<DB, Schema> & keyof DB = I['dreamInstance']['table'] & keyof DB,
-  >(
-    this: I,
-    whereStatement: WhereStatement<DB, Schema, TableName>
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  >(this: I, whereStatement: WhereStatement<DB, Schema, TableName>): Query<DreamInstance> {
     return this.queryInstance().where(whereStatement as any)
   }
 
@@ -746,10 +738,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     DB extends DreamInstance['DB'],
     Schema extends DreamInstance['schema'],
     TableName extends AssociationTableNames<DB, Schema> & keyof DB = I['dreamInstance']['table'] & keyof DB,
-  >(
-    this: I,
-    whereStatements: WhereStatement<DB, Schema, TableName>[]
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  >(this: I, whereStatements: WhereStatement<DB, Schema, TableName>[]): Query<DreamInstance> {
     return this.queryInstance().whereAny(whereStatements as any)
   }
 
@@ -772,10 +761,7 @@ export default class DreamClassTransactionBuilder<DreamInstance extends Dream> {
     DB extends DreamInstance['DB'],
     Schema extends DreamInstance['schema'],
     TableName extends AssociationTableNames<DB, Schema> & keyof DB = I['dreamInstance']['table'] & keyof DB,
-  >(
-    this: I,
-    whereStatement: WhereStatement<DB, Schema, TableName>
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  >(this: I, whereStatement: WhereStatement<DB, Schema, TableName>): Query<DreamInstance> {
     return this.queryInstance().whereNot(whereStatement as any)
   }
 }

--- a/src/dream/DreamInstanceTransactionBuilder.ts
+++ b/src/dream/DreamInstanceTransactionBuilder.ts
@@ -156,7 +156,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.queryInstance().innerJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -183,7 +183,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
     LastArg extends VariadicJoinsArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
     return this.queryInstance().leftJoin(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
   }
@@ -803,7 +803,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
    */
   private queryInstance<I extends DreamInstanceTransactionBuilder<DreamInstance>>(
     this: I
-  ): Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> {
+  ): Query<DreamInstance> {
     const dreamClass = this.dreamInstance.constructor as DreamConstructorType<DreamInstance>
     const id = this.dreamInstance.primaryKeyValue
 

--- a/src/dream/LeftJoinLoadBuilder.ts
+++ b/src/dream/LeftJoinLoadBuilder.ts
@@ -1,7 +1,10 @@
 import { PassthroughOnClause } from '../decorators/associations/shared'
 import Dream from '../Dream'
 import DreamTransaction from './DreamTransaction'
-import Query, { PreloadedDreamsAndWhatTheyPointTo, QueryWithJoinedAssociationsType } from './Query'
+import Query, {
+  PreloadedDreamsAndWhatTheyPointTo,
+  QueryWithJoinedAssociationsTypeAndNoPreload,
+} from './Query'
 import {
   IdType,
   JoinedAssociationsTypeFromAssociations,
@@ -64,8 +67,8 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
     const Arr extends readonly unknown[],
     LastArg extends VariadicLoadArgs<DB, Schema, TableName, Arr>,
   >(this: I, ...args: [...Arr, LastArg]) {
-    this.query = this.query.leftJoinPreload(...(args as any)) as QueryWithJoinedAssociationsType<
-      DreamInstance,
+    this.query = this.query.leftJoinPreload(...(args as any)) as QueryWithJoinedAssociationsTypeAndNoPreload<
+      Query<DreamInstance>,
       JoinedAssociationsTypeFromAssociations<DB, Schema, TableName, [...Arr, LastArg]>
     >
 

--- a/src/dream/LoadBuilder.ts
+++ b/src/dream/LoadBuilder.ts
@@ -1,13 +1,16 @@
 import { PassthroughOnClause } from '../decorators/associations/shared'
 import Dream from '../Dream'
 import DreamTransaction from './DreamTransaction'
-import Query, { DefaultQueryTypeOptions } from './Query'
+import Query, { DefaultQueryTypeOptions, ExtendQueryType } from './Query'
 import { PassthroughColumnNames, VariadicLoadArgs } from './types'
 
 export default class LoadBuilder<DreamInstance extends Dream> {
   private dream: Dream
   private dreamTransaction: DreamTransaction<any> | undefined
-  private query: Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>>
+  private query: Query<
+    DreamInstance,
+    ExtendQueryType<DefaultQueryTypeOptions<DreamInstance>, { allowLeftJoinPreload: false }>
+  >
 
   /**
    * An intermediate class on the way to executing a load

--- a/src/dream/internal/applyScopeBypassingSettingsToQuery.ts
+++ b/src/dream/internal/applyScopeBypassingSettingsToQuery.ts
@@ -1,9 +1,9 @@
 import Dream from '../../Dream'
-import Query, { DefaultQueryTypeOptions } from '../Query'
+import Query from '../Query'
 import { AllDefaultScopeNames } from '../types'
 
 export default function applyScopeBypassingSettingsToQuery<DreamInstance extends Dream>(
-  query: Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>>,
+  query: Query<DreamInstance>,
   {
     bypassAllDefaultScopes,
     defaultScopesToBypass,

--- a/src/dream/internal/associations/associationQuery.ts
+++ b/src/dream/internal/associations/associationQuery.ts
@@ -60,5 +60,5 @@ export default function associationQuery<
 
   return query['setBaseSQLAlias'](association.as as TableOrAssociationName<DreamInstance['schema']>)[
     'setAssociationQueryBase'
-  ](baseSelectQuery as Query<any>) as AssociationQuery
+  ](baseSelectQuery as Query<any, any>) as AssociationQuery
 }

--- a/src/dream/internal/reload.ts
+++ b/src/dream/internal/reload.ts
@@ -1,7 +1,7 @@
 import Dream from '../../Dream'
 import CannotReloadUnsavedDream from '../../errors/CannotReloadUnsavedDream'
 import DreamTransaction from '../DreamTransaction'
-import Query, { DefaultQueryTypeOptions } from '../Query'
+import Query from '../Query'
 
 export default async function reload<DreamInstance extends Dream>(
   dream: DreamInstance,
@@ -9,10 +9,7 @@ export default async function reload<DreamInstance extends Dream>(
 ) {
   if (dream.isNewRecord) throw new CannotReloadUnsavedDream(dream)
 
-  let query: Query<DreamInstance, DefaultQueryTypeOptions<DreamInstance>> = new Query<
-    DreamInstance,
-    DefaultQueryTypeOptions<DreamInstance>
-  >(dream)
+  let query: Query<DreamInstance> = new Query<DreamInstance>(dream)
 
   if (txn) query = query.txn(txn)
   // must always reload from the primary database to avoid the race condition in which changes

--- a/src/dream/types.ts
+++ b/src/dream/types.ts
@@ -913,6 +913,8 @@ export interface QueryTypeOptions {
   joinedAssociations: Readonly<JoinedAssociation[]>
   rootTableName: string
   rootTableAlias: string
+  allowPreload: boolean
+  allowLeftJoinPreload: boolean
 }
 
 export type JoinedAssociationsTypeFromAssociations<


### PR DESCRIPTION
since

For example after:

      const user = await User.query()
        .leftJoinPreload('compositions', 'localizedTexts')
        .preload('compositions', 'compositionAssets')
        .firstOrFail()

The following would raise an error since compositions would have been re-initialized during the preload
after leftJoinPreload:

      user.compositions[0].localizedTexts

Preload could be made to not re-initialize associations that had already been loaded, but the simple fact of testing whether they had been loaded would throw an error object that would be instantiated with interpolated strings, and since the mixing of leftJoinPreload and preload is so rare, it seems wrong to incur overhead during preload, which could operate on thousands of records at a time just to support an edge case.

Closes https://rvohealth.atlassian.net/browse/PDTC-7097