### PR TITLE
`order` after join supports aliased

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rvohealth/dream",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "dream orm",
   "main": "dist/src/index.js",
   "repository": "https://github.com/rvohealth/dream.git",

--- a/spec/unit/dream/all.spec.ts
+++ b/spec/unit/dream/all.spec.ts
@@ -55,7 +55,7 @@ describe('Dream.all', () => {
       it('only selects those fields', async () => {
         await User.create({ name: 'Fred', email: 'fred@frewd', password: 'howyadoin' })
 
-        const results = await User.leftJoinPreload('pets').all({ columns: ['name'] })
+        const results = await User.leftJoinPreload('pets').all({ columns: ['id', 'name'] })
         expect(results[0].name).toEqual('Fred')
         expect(results[0].email).toBeUndefined()
       })

--- a/spec/unit/query/distinct.spec.ts
+++ b/spec/unit/query/distinct.spec.ts
@@ -71,7 +71,7 @@ describe('Query#distinct', () => {
       const ids = await Edge.innerJoin('edgeNodes')
         .distinct('name')
         .where({ name: ops.similarity('myedg') })
-        .order({ name: 'desc' })
+        .order({ 'graph_edges.name': 'desc' })
         .pluck('graph_edges.id')
 
       expect(ids).toEqual([edge1.id])

--- a/src/dream/types.ts
+++ b/src/dream/types.ts
@@ -12,6 +12,7 @@ import {
 import { STI_SCOPE_NAME } from '../decorators/STI'
 import Dream from '../Dream'
 import CalendarDate from '../helpers/CalendarDate'
+import { Camelized } from '../helpers/stringCasing'
 import { FilterInterface, Inc, ReadonlyTail } from '../helpers/typeutils'
 import OpsStatement from '../ops/ops-statement'
 import DreamSerializer from '../serializer'
@@ -616,7 +617,12 @@ export type VariadicLeftJoinLoadArgs<
   ConcreteTableName,
   ConcreteArgs,
   'leftJoinLoad',
-  ConcreteTableName,
+  // Dream configures Kysely to use camel case in Typescript land and
+  // convert to snake case in SQL; however, Dream reference snake-cased table names.
+  // Without camelizing, the table name of the starting model could conflict with the
+  // snake-cased version of an association name. By camelizing the table that goes
+  // into the UsedNamespaces, we prevent this from happeing at the type level.
+  Camelized<ConcreteTableName>,
   0,
   null,
   never,
@@ -645,7 +651,13 @@ export type VariadicJoinsArgs<
   ConcreteTableName,
   ConcreteArgs,
   'join',
-  ConcreteTableName,
+  // Dream configures Kysely to use camel case in Typescript land and
+  // convert to snake case in SQL; however, Dream reference snake-cased table names.
+  // Without camelizing, the table name of the starting model could conflict with the
+  // snake-cased version of an association name. By camelizing the table that goes
+  // into the UsedNamespaces, we prevent this from happeing at the type level.
+  // Camelized<ConcreteTableName>,
+  Camelized<ConcreteTableName>,
   0,
   null,
   never,


### PR DESCRIPTION
columns. Fix pluck after join+order.

Closes https://rvohealth.atlassian.net/browse/PDTC-7227