### PR TITLE
Fix aliasing of `order` and `distinct` when

### DIFF
--- a/spec/unit/dream/distinct.spec.ts
+++ b/spec/unit/dream/distinct.spec.ts
@@ -110,6 +110,22 @@ describe('Dream.distinct', () => {
           const reloaded = await Pet.preload('distinctBalloons').first()
           expect(reloaded?.distinctBalloons).toMatchDreamModels([balloon])
         })
+
+        context('when the association name is aliased', () => {
+          it('applies distinct clause to association upon loading', async () => {
+            const pet = await Pet.create()
+            const balloon = await Latex.create()
+            await pet.createAssociation('collars', {
+              balloon,
+            })
+            await pet.createAssociation('collars', {
+              balloon,
+            })
+
+            const reloaded = await Pet.preload('distinctBalloons as db').first()
+            expect(reloaded?.distinctBalloons).toMatchDreamModels([balloon])
+          })
+        })
       })
     })
 

--- a/spec/unit/query/leftJoinPreload/simple-associations.spec.ts
+++ b/spec/unit/query/leftJoinPreload/simple-associations.spec.ts
@@ -371,6 +371,22 @@ describe('Query#leftJoinPreload with simple associations', () => {
         expect(reloadedUser.reverseOrderedCompositions[0]).toMatchDreamModel(lastComposition)
         expect(reloadedUser.reverseOrderedCompositions[1]).toMatchDreamModel(firstComposition)
       })
+
+      context('when the asscociation has been aliased', () => {
+        it('loads the associated object', async () => {
+          const user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+          const firstComposition = await Composition.create({
+            user,
+          })
+          const lastComposition = await Composition.create({
+            user,
+          })
+
+          const reloadedUser = await User.leftJoinPreload('reverseOrderedCompositions as roc').firstOrFail()
+          expect(reloadedUser.reverseOrderedCompositions[0]).toMatchDreamModel(lastComposition)
+          expect(reloadedUser.reverseOrderedCompositions[1]).toMatchDreamModel(firstComposition)
+        })
+      })
     })
   })
 

--- a/spec/unit/query/preload/through-associations.spec.ts
+++ b/spec/unit/query/preload/through-associations.spec.ts
@@ -737,6 +737,15 @@ describe('Query#preload through', () => {
       expect(node!.edgesOrderedByName[2]).toMatchDreamModel(edge1)
     })
 
+    context('aliased', () => {
+      it('orders the results based on the order specified in the association', async () => {
+        const node = await Node.preload('edgesOrderedByName as eobn').first()
+        expect(node!.edgesOrderedByName[0]).toMatchDreamModel(edge2)
+        expect(node!.edgesOrderedByName[1]).toMatchDreamModel(edge3)
+        expect(node!.edgesOrderedByName[2]).toMatchDreamModel(edge1)
+      })
+    })
+
     context('order on the association we’re going through', () => {
       it('orders the results based on the order specified in the association', async () => {
         const node = await Node.preload('edgesOrderedByPosition').first()


### PR DESCRIPTION
defined on an association that goes through
another association and the association
name in the join statement is aliased