### PR TITLE
Add updateOrCreateBy and createOrUpdateBy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/create.spec.ts
+++ b/spec/unit/dream/create.spec.ts
@@ -36,6 +36,15 @@ describe('Dream.create', () => {
     expect(reloadedUser!.updatedAt.toSeconds()).toBeWithin(1, DateTime.now().toSeconds())
   })
 
+  context('skipHooks is passed', () => {
+    it('skips model hooks', async () => {
+      await Pet.create({ species: 'dog', name: 'change me' }, { skipHooks: true })
+      const pet = await Pet.first()
+      expect(pet!.name).toEqual('change me')
+      expect(await Pet.count()).toEqual(1)
+    })
+  })
+
   context('given a transaction', () => {
     it('saves the record', async () => {
       let user: User | null = null

--- a/spec/unit/dream/createOrUpdateBy.spec.ts
+++ b/spec/unit/dream/createOrUpdateBy.spec.ts
@@ -1,0 +1,161 @@
+import CreateOrUpdateByFailedToCreateAndUpdate from '../../../src/errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
+import Composition from '../../../test-app/app/models/Composition.js'
+import Pet from '../../../test-app/app/models/Pet.js'
+import User from '../../../test-app/app/models/User.js'
+
+describe('Dream.createOrUpdateBy', () => {
+  context('no underlying conflicts to prevent save', () => {
+    it('creates the underlying model in the db', async () => {
+      const u = await User.createOrUpdateBy({ email: 'trace@trace' }, { with: { password: 'howyadoin' } })
+
+      const user = await User.find(u.id)
+      expect(user!.email).toEqual('trace@trace')
+      expect(await user!.checkPassword('howyadoin')).toEqual(true)
+    })
+
+    it('respects associations in primary opts with user', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy({ user }, { with: { content: 'howyadoin' } })
+
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('howyadoin')
+    })
+
+    it('respects associations in primary opts with userId', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy(
+        { userId: user.id },
+        { with: { content: 'howyadoin' } }
+      )
+
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('howyadoin')
+    })
+
+    it('respects associations in secondary opts with user', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy({ content: 'howyadoin' }, { with: { user } })
+
+      expect(composition.userId).toEqual(user.id)
+    })
+
+    it('respects associations in secondary opts with userId', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy(
+        { content: 'howyadoin' },
+        { with: { userId: user.id } }
+      )
+
+      expect(composition.userId).toEqual(user.id)
+    })
+
+    context('skipHooks is passed', () => {
+      it('skips model hooks', async () => {
+        await Pet.createOrUpdateBy({ species: 'dog' }, { with: { name: 'change me' }, skipHooks: true })
+
+        const pet = await Pet.first()
+        expect(pet!.name).toEqual('change me')
+        expect(await Pet.count()).toEqual(1)
+      })
+    })
+  })
+
+  context('when a conflicting record already exists in the db', () => {
+    let user: User
+
+    beforeEach(async () => {
+      user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    })
+
+    it('updates the existing record', async () => {
+      const u = await User.createOrUpdateBy({ email: 'trace@trace' }, { with: { password: 'newpassword' } })
+      const user = await User.find(u.id)
+      expect(user!.email).toEqual('trace@trace')
+      expect(await user!.checkPassword('newpassword')).toEqual(true)
+    })
+
+    it('returns the existing record if there are no updates to with', async () => {
+      await Pet.create({ species: 'dog', name: 'Baron' })
+
+      const p = await Pet.createOrUpdateBy({
+        species: 'dog',
+        name: 'Baron',
+      })
+
+      expect(p.species).toEqual('dog')
+      expect(p.name).toEqual('Baron')
+    })
+
+    it('respects associations in primary opts with user', async () => {
+      await Composition.create({ user, content: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy({ user }, { with: { content: 'newcontent' } })
+
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('newcontent')
+    })
+
+    it('respects associations in primary opts with userId', async () => {
+      await Composition.create({ user, content: 'howyadoin' })
+      const composition = await Composition.createOrUpdateBy(
+        { userId: user.id },
+        { with: { content: 'newcontent' } }
+      )
+
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('newcontent')
+    })
+
+    it('respects associations in secondary opts with user', async () => {
+      const otherUser = await User.create({ email: 'trace@hi', password: 'notbad' })
+      await Composition.create({ content: 'howyadoin', user: otherUser })
+
+      const composition = await Composition.createOrUpdateBy({ content: 'howyadoin' }, { with: { user } })
+
+      expect(composition.userId).toEqual(user.id)
+    })
+
+    it('respects associations in secondary opts with userId', async () => {
+      const otherUser = await User.create({ email: 'new@trace', password: 'notbad' })
+      await Composition.create({ content: 'howyadoin', user: otherUser })
+
+      const composition = await Composition.createOrUpdateBy(
+        { content: 'howyadoin' },
+        { with: { userId: user.id } }
+      )
+
+      expect(composition.userId).toEqual(user.id)
+    })
+
+    context('skipHooks is passed', () => {
+      it('skips model hooks', async () => {
+        await Pet.createOrUpdateBy({ species: 'dog' }, { with: { name: 'change me' }, skipHooks: true })
+
+        const pet = await Pet.first()
+        expect(pet!.name).toEqual('change me')
+        expect(await Pet.count()).toEqual(1)
+      })
+    })
+  })
+
+  context(
+    'when createOrUpdateBy attribute doesn’t match an existing record, but a `with` field conflicts with an existing record',
+    () => {
+      beforeEach(async () => {
+        await User.create({
+          email: 'fred@fred',
+          socialSecurityNumber: '1234567890',
+          password: 'howyadoin',
+        })
+      })
+
+      it('throws CreateOrUpdateByFailedToCreateAndUpdate', async () => {
+        await expect(
+          User.createOrUpdateBy(
+            { email: 'howya@doin' },
+            { with: { socialSecurityNumber: '1234567890', password: 'nothowyadoin' } }
+          )
+        ).rejects.toThrow(CreateOrUpdateByFailedToCreateAndUpdate)
+      })
+    }
+  )
+})

--- a/spec/unit/dream/findOrCreateBy.spec.ts
+++ b/spec/unit/dream/findOrCreateBy.spec.ts
@@ -38,4 +38,13 @@ describe('Dream.findOrCreateBy', () => {
     const composition = await Composition.findOrCreateBy({ content: 'howyadoin' }, { createWith: { user } })
     expect(composition.userId).toEqual(user.id)
   })
+
+  it('respects associations in secondary opts with userId', async () => {
+    const user = await User.create({ email: 'fred@fred.fred', password: 'howyadoin' })
+    const composition = await Composition.findOrCreateBy(
+      { content: 'howyadoin' },
+      { createWith: { userId: user.id } }
+    )
+    expect(composition.userId).toEqual(user.id)
+  })
 })

--- a/spec/unit/dream/findOrCreateBy.spec.ts
+++ b/spec/unit/dream/findOrCreateBy.spec.ts
@@ -1,3 +1,4 @@
+import ApplicationModel from '../../../test-app/app/models/ApplicationModel.js'
 import Composition from '../../../test-app/app/models/Composition.js'
 import User from '../../../test-app/app/models/User.js'
 
@@ -46,5 +47,22 @@ describe('Dream.findOrCreateBy', () => {
       { createWith: { userId: user.id } }
     )
     expect(composition.userId).toEqual(user.id)
+  })
+
+  context('given a transaction', () => {
+    it('creates the underlying model in the db', async () => {
+      let u: User | null = null
+
+      await ApplicationModel.transaction(async txn => {
+        u = await User.txn(txn).findOrCreateBy(
+          { email: 'fred@frewd' },
+          { createWith: { password: 'howyadoin' } }
+        )
+      })
+
+      const user = await User.find(u!.id)
+      expect(user!.email).toEqual('fred@frewd')
+      expect(await user!.checkPassword('howyadoin')).toEqual(true)
+    })
   })
 })

--- a/spec/unit/dream/save.spec.ts
+++ b/spec/unit/dream/save.spec.ts
@@ -18,11 +18,6 @@ describe('Dream#save', () => {
       expect(reloadedUser).toMatchDreamModel(user)
     })
 
-    it('returns the dream model', async () => {
-      const saved = await user.save()
-      expect(saved).toMatchDreamModel(user)
-    })
-
     context('skipHooks is passed', () => {
       it('skips model hooks', async () => {
         const pet = Pet.new({ name: 'change me' })

--- a/spec/unit/dream/save.spec.ts
+++ b/spec/unit/dream/save.spec.ts
@@ -18,6 +18,11 @@ describe('Dream#save', () => {
       expect(reloadedUser).toMatchDreamModel(user)
     })
 
+    it('returns the dream model', async () => {
+      const saved = await user.save()
+      expect(saved).toMatchDreamModel(user)
+    })
+
     context('skipHooks is passed', () => {
       it('skips model hooks', async () => {
         const pet = Pet.new({ name: 'change me' })

--- a/spec/unit/dream/transaction.spec.ts
+++ b/spec/unit/dream/transaction.spec.ts
@@ -17,6 +17,17 @@ describe('ApplicationModel.transaction', () => {
     expect(user.email).toEqual('fred@fishman')
   })
 
+  it('txn can receive null', async () => {
+    const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+
+    await Composition.txn(null).create({ user })
+    await user.txn(null).update({ email: 'fred@fishman' })
+
+    expect(await Composition.count()).toEqual(1)
+    await User.find(user.id)
+    expect(user.email).toEqual('fred@fishman')
+  })
+
   it('returns whatever was returned in the underlying callback', async () => {
     const res = await ApplicationModel.transaction(async txn => {
       await User.txn(txn).first()

--- a/spec/unit/dream/updateOrCreateBy.spec.ts
+++ b/spec/unit/dream/updateOrCreateBy.spec.ts
@@ -1,3 +1,4 @@
+import ApplicationModel from '../../../test-app/app/models/ApplicationModel.js'
 import Composition from '../../../test-app/app/models/Composition.js'
 import Pet from '../../../test-app/app/models/Pet.js'
 import User from '../../../test-app/app/models/User.js'
@@ -55,6 +56,23 @@ describe('Dream.updateOrCreateBy', () => {
         const pet = await Pet.first()
         expect(pet!.name).toEqual('change me')
         expect(await Pet.count()).toEqual(1)
+      })
+    })
+
+    context('given a transaction', () => {
+      it('creates the underlying model in the db', async () => {
+        let u: User | null = null
+
+        await ApplicationModel.transaction(async txn => {
+          u = await User.txn(txn).updateOrCreateBy(
+            { email: 'trace@trace' },
+            { with: { password: 'howyadoin' } }
+          )
+        })
+
+        const user = await User.find(u!.id)
+        expect(user!.email).toEqual('trace@trace')
+        expect(await user!.checkPassword('howyadoin')).toEqual(true)
       })
     })
   })
@@ -129,6 +147,23 @@ describe('Dream.updateOrCreateBy', () => {
         const pet = await Pet.first()
         expect(pet!.name).toEqual('change me')
         expect(await Pet.count()).toEqual(1)
+      })
+    })
+
+    context('given a transaction', () => {
+      it('creates the underlying model in the db', async () => {
+        let u: User | null = null
+
+        await ApplicationModel.transaction(async txn => {
+          u = await User.txn(txn).updateOrCreateBy(
+            { email: 'trace@trace' },
+            { with: { password: 'newpassword' } }
+          )
+        })
+
+        const user = await User.find(u!.id)
+        expect(user!.email).toEqual('trace@trace')
+        expect(await user!.checkPassword('newpassword')).toEqual(true)
       })
     })
   })

--- a/spec/unit/dream/updateOrCreateBy.spec.ts
+++ b/spec/unit/dream/updateOrCreateBy.spec.ts
@@ -6,6 +6,7 @@ describe('Dream.updateOrCreateBy', () => {
   context('no underlying conflicts to prevent save', () => {
     it('creates the underlying model in the db', async () => {
       const u = await User.updateOrCreateBy({ email: 'trace@frewd' }, { with: { password: 'howyadoin' } })
+
       const user = await User.find(u.id)
       expect(user!.email).toEqual('trace@frewd')
       expect(await user!.checkPassword('howyadoin')).toEqual(true)
@@ -14,6 +15,7 @@ describe('Dream.updateOrCreateBy', () => {
     it('respects associations in primary opts with user', async () => {
       const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
       const composition = await Composition.updateOrCreateBy({ user }, { with: { content: 'howyadoin' } })
+
       expect(composition.userId).toEqual(user.id)
       expect(composition.content).toEqual('howyadoin')
     })
@@ -24,6 +26,7 @@ describe('Dream.updateOrCreateBy', () => {
         { userId: user.id },
         { with: { content: 'howyadoin' } }
       )
+
       expect(composition.userId).toEqual(user.id)
       expect(composition.content).toEqual('howyadoin')
     })
@@ -31,6 +34,7 @@ describe('Dream.updateOrCreateBy', () => {
     it('respects associations in secondary opts with user', async () => {
       const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
       const composition = await Composition.updateOrCreateBy({ content: 'howyadoin' }, { with: { user } })
+
       expect(composition.userId).toEqual(user.id)
     })
 
@@ -40,12 +44,14 @@ describe('Dream.updateOrCreateBy', () => {
         { content: 'howyadoin' },
         { with: { userId: user.id } }
       )
+
       expect(composition.userId).toEqual(user.id)
     })
 
     context('skipHooks is passed', () => {
       it('skips model hooks', async () => {
         await Pet.updateOrCreateBy({ species: 'dog' }, { with: { name: 'change me' }, skipHooks: true })
+
         const pet = await Pet.first()
         expect(pet!.name).toEqual('change me')
         expect(await Pet.count()).toEqual(1)
@@ -70,13 +76,13 @@ describe('Dream.updateOrCreateBy', () => {
     it('returns the existing record if there are no updates to with', async () => {
       await user.update({ favoriteWord: 'hi' })
       const u = await User.updateOrCreateBy({ email: 'trace@trace', favoriteWord: 'hi' })
+
       expect(u.email).toEqual('trace@trace')
       expect(u.favoriteWord).toEqual('hi')
     })
 
     it('respects associations in primary opts with user', async () => {
       await Composition.create({ user, content: 'howyadoin' })
-
       const composition = await Composition.updateOrCreateBy({ user }, { with: { content: 'newcontent' } })
 
       expect(composition.userId).toEqual(user.id)
@@ -85,7 +91,6 @@ describe('Dream.updateOrCreateBy', () => {
 
     it('respects associations in primary opts with userId', async () => {
       await Composition.create({ user, content: 'howyadoin' })
-
       const composition = await Composition.updateOrCreateBy(
         { userId: user.id },
         { with: { content: 'newcontent' } }
@@ -100,6 +105,7 @@ describe('Dream.updateOrCreateBy', () => {
       await Composition.create({ content: 'howyadoin', user: otherUser })
 
       const composition = await Composition.updateOrCreateBy({ content: 'howyadoin' }, { with: { user } })
+
       expect(composition.userId).toEqual(user.id)
     })
 
@@ -111,6 +117,7 @@ describe('Dream.updateOrCreateBy', () => {
         { content: 'howyadoin' },
         { with: { userId: user.id } }
       )
+
       expect(composition.userId).toEqual(user.id)
     })
 
@@ -118,6 +125,7 @@ describe('Dream.updateOrCreateBy', () => {
       it('skips model hooks', async () => {
         const { species } = await Pet.create()
         await Pet.updateOrCreateBy({ species }, { with: { name: 'change me' }, skipHooks: true })
+
         const pet = await Pet.first()
         expect(pet!.name).toEqual('change me')
         expect(await Pet.count()).toEqual(1)

--- a/spec/unit/dream/updateOrCreateBy.spec.ts
+++ b/spec/unit/dream/updateOrCreateBy.spec.ts
@@ -5,7 +5,6 @@ describe('Dream.updateOrCreateBy', () => {
   context('no underlying conflicts to prevent save', () => {
     it('creates the underlying model in the db', async () => {
       const u = await User.updateOrCreateBy({ email: 'trace@frewd' }, { with: { password: 'howyadoin' } })
-      // attributes consistently or attributes here / createWith on findOrCreateBy
       const user = await User.find(u.id)
       expect(user!.email).toEqual('trace@frewd')
       expect(await user!.checkPassword('howyadoin')).toEqual(true)

--- a/spec/unit/dream/updateOrCreateBy.spec.ts
+++ b/spec/unit/dream/updateOrCreateBy.spec.ts
@@ -1,0 +1,103 @@
+import Composition from '../../../test-app/app/models/Composition.js'
+import User from '../../../test-app/app/models/User.js'
+
+describe('Dream.updateOrCreateBy', () => {
+  context('no underlying conflicts to prevent save', () => {
+    it('creates the underlying model in the db', async () => {
+      const u = await User.updateOrCreateBy({ email: 'trace@frewd' }, { with: { password: 'howyadoin' } })
+      // attributes consistently or attributes here / createWith on findOrCreateBy
+      const user = await User.find(u.id)
+      expect(user!.email).toEqual('trace@frewd')
+      expect(await user!.checkPassword('howyadoin')).toEqual(true)
+    })
+
+    it('respects associations in primary opts with user', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.updateOrCreateBy({ user }, { with: { content: 'howyadoin' } })
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('howyadoin')
+    })
+
+    it('respects associations in primary opts with userId', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.updateOrCreateBy(
+        { userId: user.id },
+        { with: { content: 'howyadoin' } }
+      )
+      expect(composition.userId).toEqual(user.id)
+      expect(composition.content).toEqual('howyadoin')
+    })
+
+    it('respects associations in secondary opts with user', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.updateOrCreateBy({ content: 'howyadoin' }, { with: { user } })
+      expect(composition.userId).toEqual(user.id)
+    })
+
+    it('respects associations in secondary opts with userId', async () => {
+      const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+      const composition = await Composition.updateOrCreateBy(
+        { content: 'howyadoin' },
+        { with: { userId: user.id } }
+      )
+      expect(composition.userId).toEqual(user.id)
+    })
+  })
+
+  context('when a conflicting record already exists in the db', () => {
+    beforeEach(async () => {
+      await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    })
+
+    it('updates the existing record', async () => {
+      const u = await User.updateOrCreateBy({ email: 'trace@trace' }, { with: { password: 'newpassword' } })
+      const user = await User.find(u.id)
+      expect(user!.email).toEqual('trace@trace')
+      expect(await user!.checkPassword('newpassword')).toEqual(true)
+    })
+  })
+
+  it('respects associations in primary opts with user', async () => {
+    const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    await Composition.create({ user, content: 'howyadoin' })
+
+    const composition = await Composition.updateOrCreateBy({ user }, { with: { content: 'newcontent' } })
+
+    expect(composition.userId).toEqual(user.id)
+    expect(composition.content).toEqual('newcontent')
+  })
+
+  it('respects associations in primary opts with userId', async () => {
+    const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    await Composition.create({ user, content: 'howyadoin' })
+
+    const composition = await Composition.updateOrCreateBy(
+      { userId: user.id },
+      { with: { content: 'newcontent' } }
+    )
+
+    expect(composition.userId).toEqual(user.id)
+    expect(composition.content).toEqual('newcontent')
+  })
+
+  it('respects associations in secondary opts with user', async () => {
+    const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    const otherUser = await User.create({ email: 'trace@hi', password: 'notbad' })
+    await Composition.create({ content: 'howyadoin', user: otherUser })
+
+    const composition = await Composition.updateOrCreateBy({ content: 'howyadoin' }, { with: { user } })
+    expect(composition.userId).toEqual(user.id)
+  })
+
+  it('respects associations in secondary opts with userId', async () => {
+    const user = await User.create({ email: 'trace@trace', password: 'howyadoin' })
+    const otherUser = await User.create({ email: 'new@trace', password: 'notbad' })
+    await Composition.create({ content: 'howyadoin', user: otherUser })
+
+    const composition = await Composition.updateOrCreateBy(
+      { content: 'howyadoin' },
+      { with: { userId: user.id } }
+    )
+    expect(composition.userId).toEqual(user.id)
+  })
+})

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -3927,9 +3927,7 @@ export default class Dream {
 }
 
 export interface CreateOrFindByExtraOpts<T extends typeof Dream> {
-  createWith?:
-    | WhereStatement<InstanceType<T>['DB'], InstanceType<T>['schema'], InstanceType<T>['table']>
-    | UpdateablePropertiesForClass<T>
+  createWith?: UpdateablePropertiesForClass<T>
 }
 
 export interface UpdateOrCreateByExtraOpts<T extends typeof Dream> {

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -26,6 +26,7 @@ import {
 } from './dream/internal/destroyOptions.js'
 import ensureSTITypeFieldIsSet from './dream/internal/ensureSTITypeFieldIsSet.js'
 import extractAssociationMetadataFromAssociationName from './dream/internal/extractAssociationMetadataFromAssociationName.js'
+import findOrCreateBy from './dream/internal/findOrCreateBy.js'
 import reload from './dream/internal/reload.js'
 import runValidations from './dream/internal/runValidations.js'
 import saveDream from './dream/internal/saveDream.js'
@@ -35,6 +36,7 @@ import {
   DEFAULT_SKIP_HOOKS,
 } from './dream/internal/scopeHelpers.js'
 import undestroyDream from './dream/internal/undestroyDream.js'
+import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
 import LeftJoinLoadBuilder from './dream/LeftJoinLoadBuilder.js'
 import LoadBuilder from './dream/LoadBuilder.js'
 import Query from './dream/Query.js'
@@ -48,6 +50,7 @@ import NonLoadedAssociation from './errors/associations/NonLoadedAssociation.js'
 import CannotCallUndestroyOnANonSoftDeleteModel from './errors/CannotCallUndestroyOnANonSoftDeleteModel.js'
 import ConstructorOnlyForInternalUse from './errors/ConstructorOnlyForInternalUse.js'
 import CreateOrFindByFailedToCreateAndFind from './errors/CreateOrFindByFailedToCreateAndFind.js'
+import CreateOrUpdateByFailedToCreateAndUpdate from './errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
 import GlobalNameNotSet from './errors/dream-app/GlobalNameNotSet.js'
 import DreamMissingRequiredOverride from './errors/DreamMissingRequiredOverride.js'
 import MissingSerializer from './errors/MissingSerializersDefinition.js'
@@ -112,9 +115,6 @@ import {
   VariadicLeftJoinLoadArgs,
   VariadicLoadArgs,
 } from './types/variadic.js'
-import findOrCreateBy from './dream/internal/findOrCreateBy.js'
-import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
-import CreateOrUpdateByFailedToCreateAndUpdate from './errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
 
 export default class Dream {
   public DB: any
@@ -1664,7 +1664,7 @@ export default class Dream {
    */
   public static txn<T extends typeof Dream, I extends InstanceType<T>>(
     this: T,
-    txn: DreamTransaction<I>
+    txn: DreamTransaction<I> | null
   ): DreamClassTransactionBuilder<T, I> {
     return new DreamClassTransactionBuilder<T, I>(this, txn)
   }
@@ -3830,7 +3830,10 @@ export default class Dream {
    * @param txn - A DreamTransaction instance (collected by calling `ApplicationModel.transaction`)
    * @returns A Query scoped to this model with the transaction applied
    */
-  public txn<I extends Dream>(this: I, txn: DreamTransaction<Dream>): DreamInstanceTransactionBuilder<I> {
+  public txn<I extends Dream>(
+    this: I,
+    txn: DreamTransaction<Dream> | null
+  ): DreamInstanceTransactionBuilder<I> {
     return new DreamInstanceTransactionBuilder<I>(this, txn)
   }
 

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -901,7 +901,7 @@ export default class Dream {
       }
     }
 
-    return this.create(
+    return await this.create(
       {
         ...attributes,
         ...(extraOpts?.with || {}),

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -114,6 +114,7 @@ import {
 } from './types/variadic.js'
 import findOrCreateBy from './dream/internal/findOrCreateBy.js'
 import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
+import CreateOrUpdateByFailedToCreateAndUpdate from './errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
 
 export default class Dream {
   public DB: any
@@ -883,7 +884,7 @@ export default class Dream {
    * const user = await User.updateOrCreateBy({ email }, { with: { name: 'Alice' })
    * ```
    *
-   * @param attributes - The base attributes for finding, but also the attributes to use when creating
+   * @param attributes - The base attributes for finding which record to update, also used when creating
    * @param extraOpts.with - additional attributes to persist when updating and creating, but not used for finding
    * @param extraOpts.skipHooks - if true, will skip applying model hooks. Defaults to false
    * @returns A dream instance
@@ -894,6 +895,57 @@ export default class Dream {
     extraOpts: UpdateOrCreateByExtraOpts<T> = {}
   ): Promise<InstanceType<T>> {
     return await updateOrCreateBy(this, null, attributes, extraOpts)
+  }
+
+  /**
+   * Attempt to create the model with the given attributes.
+   * If creation fails due to uniqueness constraint, then find and update
+   * the existing model. All lifecycle hooks are run for whichever
+   * action is taken.
+   *
+   * This is useful in situations where we want to avoid
+   * a race condition creating duplicate records.
+   *
+   * IMPORTANT: A unique index/uniqueness constraint must exist on
+   * at least one of the provided attributes
+   *
+   * @param attributes - The base attributes for finding which record to update, also used when creating
+   * @param extraOpts.with - additional attributes to persist when updating and creating, but not used for finding
+   * @param extraOpts.skipHooks - if true, will skip applying model hooks. Defaults to false
+   * @returns A dream instance
+   */
+  public static async createOrUpdateBy<T extends typeof Dream>(
+    this: T,
+    attributes: UpdateablePropertiesForClass<T>,
+    extraOpts: UpdateOrCreateByExtraOpts<T> = {}
+  ): Promise<InstanceType<T>> {
+    const { skipHooks } = extraOpts
+
+    try {
+      return await this.create(
+        {
+          ...attributes,
+          ...(extraOpts?.with || {}),
+        },
+        skipHooks ? { skipHooks } : undefined
+      )
+    } catch (err) {
+      if (pgErrorType(err) === 'UNIQUE_CONSTRAINT_VIOLATION') {
+        const existingRecord = await this.findBy(this.extractAttributesFromUpdateableProperties(attributes))
+        if (!existingRecord) throw new CreateOrUpdateByFailedToCreateAndUpdate(this)
+        const { with: attrs } = extraOpts
+
+        if (existingRecord) {
+          if (attrs) {
+            existingRecord.assignAttributes(attrs)
+            return await saveDream(existingRecord, null, skipHooks ? { skipHooks } : undefined)
+          } else {
+            return existingRecord
+          }
+        }
+      }
+      throw err
+    }
   }
 
   /**

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -936,12 +936,8 @@ export default class Dream {
         const { with: attrs } = extraOpts
 
         if (existingRecord) {
-          if (attrs) {
-            existingRecord.assignAttributes(attrs)
-            return await saveDream(existingRecord, null, skipHooks ? { skipHooks } : undefined)
-          } else {
-            return existingRecord
-          }
+          existingRecord.assignAttributes(attrs ?? {})
+          return await saveDream(existingRecord, null, skipHooks ? { skipHooks } : undefined)
         }
       }
       throw err

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -113,6 +113,7 @@ import {
   VariadicLoadArgs,
 } from './types/variadic.js'
 import findOrCreateBy from './dream/internal/findOrCreateBy.js'
+import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
 
 export default class Dream {
   public DB: any
@@ -892,25 +893,7 @@ export default class Dream {
     attributes: UpdateablePropertiesForClass<T>,
     extraOpts: UpdateOrCreateByExtraOpts<T> = {}
   ): Promise<InstanceType<T>> {
-    const existingRecord = await this.findBy(this.extractAttributesFromUpdateableProperties(attributes))
-    const { with: attrs, skipHooks } = extraOpts
-
-    if (existingRecord) {
-      if (attrs) {
-        existingRecord.assignAttributes(attrs)
-        return await saveDream(existingRecord, null, skipHooks ? { skipHooks } : undefined)
-      } else {
-        return existingRecord
-      }
-    }
-
-    return await this.create(
-      {
-        ...attributes,
-        ...(extraOpts?.with || {}),
-      },
-      skipHooks ? { skipHooks } : undefined
-    )
+    return await updateOrCreateBy(this, null, attributes, extraOpts)
   }
 
   /**

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -295,7 +295,7 @@ export default class DreamClassTransactionBuilder<
   public async findOrCreateBy<I extends DreamClassTransactionBuilder<DreamClass, DreamInstance>>(
     this: I,
     attributes: UpdateablePropertiesForClass<DreamClass>,
-    extraOpts: CreateOrFindByExtraOptsForDreamInstance<DreamInstance> = {}
+    extraOpts: CreateOrFindByExtraOpts<DreamClass> = {}
   ): Promise<InstanceType<DreamClass>> {
     return await findOrCreateBy(this.dreamClass, this.dreamTransaction, attributes, extraOpts)
   }

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -29,10 +29,10 @@ import {
   VariadicLoadArgs,
 } from '../types/variadic.js'
 import DreamTransaction from './DreamTransaction.js'
-import saveDream from './internal/saveDream.js'
-import Query from './Query.js'
 import findOrCreateBy from './internal/findOrCreateBy.js'
+import saveDream from './internal/saveDream.js'
 import updateOrCreateBy from './internal/updateOrCreateBy.js'
+import Query from './Query.js'
 
 export default class DreamClassTransactionBuilder<
   DreamClass extends typeof Dream,
@@ -47,8 +47,8 @@ export default class DreamClassTransactionBuilder<
    * @param txn - The DreamTransaction instance
    */
   constructor(
-    public dreamClass: DreamClass,
-    public dreamTransaction: DreamTransaction<Dream>
+    private dreamClass: DreamClass,
+    private dreamTransaction: DreamTransaction<Dream> | null
   ) {
     this.dreamInstance = dreamClass.prototype as DreamInstance
   }

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -1,9 +1,8 @@
-import { SelectArg, SelectExpression, Updateable } from 'kysely'
+import { SelectArg, SelectExpression } from 'kysely'
 import Dream, { CreateOrFindByExtraOpts } from '../Dream.js'
 import { PassthroughOnClause, WhereStatement } from '../types/associations/shared.js'
 import { AssociationTableNames } from '../types/db.js'
 import {
-  CreateOrFindByExtraOptsForDreamInstance,
   DefaultScopeName,
   DreamColumnNames,
   OrderDir,
@@ -32,7 +31,6 @@ import DreamTransaction from './DreamTransaction.js'
 import saveDream from './internal/saveDream.js'
 import Query from './Query.js'
 import findOrCreateBy from './internal/findOrCreateBy.js'
-import ApplicationModel from '../../test-app/app/models/ApplicationModel.js'
 import updateOrCreateBy from './internal/updateOrCreateBy.js'
 
 export default class DreamClassTransactionBuilder<

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -3,6 +3,7 @@ import Dream from '../Dream.js'
 import { PassthroughOnClause, WhereStatement } from '../types/associations/shared.js'
 import { AssociationTableNames } from '../types/db.js'
 import {
+  CreateOrFindByExtraOpts,
   DefaultScopeName,
   DreamColumnNames,
   OrderDir,

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -1,5 +1,5 @@
 import { SelectArg, SelectExpression } from 'kysely'
-import Dream, { CreateOrFindByExtraOpts } from '../Dream.js'
+import Dream from '../Dream.js'
 import { PassthroughOnClause, WhereStatement } from '../types/associations/shared.js'
 import { AssociationTableNames } from '../types/db.js'
 import {

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -190,7 +190,7 @@ export default class DreamClassTransactionBuilder<
     attributes?: UpdateableProperties<DreamInstance>,
     { skipHooks }: { skipHooks?: boolean } = {}
   ): Promise<DreamInstance> {
-    const dream = (this.dreamInstance.constructor as typeof Dream).new(attributes) as DreamInstance
+    const dream = this.dreamClass.new(attributes) as DreamInstance
     return saveDream<DreamInstance>(dream, this.dreamTransaction, skipHooks ? { skipHooks } : undefined)
   }
 

--- a/src/dream/DreamInstanceTransactionBuilder.ts
+++ b/src/dream/DreamInstanceTransactionBuilder.ts
@@ -49,19 +49,16 @@ import LoadBuilder from './LoadBuilder.js'
 import Query from './Query.js'
 
 export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream> {
-  public dreamInstance: DreamInstance
-  public dreamTransaction: DreamTransaction<Dream>
-
   /**
    * Constructs a new DreamInstanceTransactionBuilder.
    *
    * @param dreamInstance - The Dream instance to build the transaction for
    * @param txn - The DreamTransaction instance
    */
-  constructor(dreamInstance: DreamInstance, txn: DreamTransaction<Dream>) {
-    this.dreamInstance = dreamInstance
-    this.dreamTransaction = txn
-  }
+  constructor(
+    private dreamInstance: DreamInstance,
+    private dreamTransaction: DreamTransaction<Dream> | null
+  ) {}
 
   /**
    * Loads the requested associations upon execution

--- a/src/dream/LeftJoinLoadBuilder.ts
+++ b/src/dream/LeftJoinLoadBuilder.ts
@@ -12,7 +12,6 @@ import Query from './Query.js'
 
 export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
   private dream: Dream
-  private dreamTransaction: DreamTransaction<any> | undefined
   private query: QueryWithJoinedAssociationsTypeAndNoPreload<Query<DreamInstance>>
 
   /**
@@ -25,7 +24,10 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
    * await user.load('settings').execute()
    * ```
    */
-  constructor(dream: Dream, txn?: DreamTransaction<any>) {
+  constructor(
+    dream: Dream,
+    private dreamTransaction?: DreamTransaction<any> | null
+  ) {
     this.dream = dream['clone']()
 
     // Load queries start from the table corresponding to an instance
@@ -35,7 +37,6 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
     // to other associations (thus the use of `removeAllDefaultScopesExceptOnAssociations`
     // instead of `removeAllDefaultScopes`).
     this.query = (this.dream as any).query()['removeAllDefaultScopesExceptOnAssociations']()
-    this.dreamTransaction = txn
   }
 
   public passthrough<

--- a/src/dream/LoadBuilder.ts
+++ b/src/dream/LoadBuilder.ts
@@ -8,7 +8,6 @@ import Query from './Query.js'
 
 export default class LoadBuilder<DreamInstance extends Dream> {
   private dream: Dream
-  private dreamTransaction: DreamTransaction<any> | undefined
   private query: QueryWithJoinedAssociationsTypeAndNoLeftJoinPreload<Query<DreamInstance>>
 
   /**
@@ -21,7 +20,10 @@ export default class LoadBuilder<DreamInstance extends Dream> {
    * await user.load('settings').execute()
    * ```
    */
-  constructor(dream: Dream, txn?: DreamTransaction<any>) {
+  constructor(
+    dream: Dream,
+    private dreamTransaction?: DreamTransaction<any> | null
+  ) {
     this.dream = dream['clone']()
 
     // Load queries start from the table corresponding to an instance
@@ -31,7 +33,6 @@ export default class LoadBuilder<DreamInstance extends Dream> {
     // to other associations (thus the use of `removeAllDefaultScopesExceptOnAssociations`
     // instead of `removeAllDefaultScopes`).
     this.query = (this.dream as any).query()['removeAllDefaultScopesExceptOnAssociations']()
-    this.dreamTransaction = txn
   }
 
   public passthrough<

--- a/src/dream/Query.ts
+++ b/src/dream/Query.ts
@@ -1493,7 +1493,7 @@ export default class Query<
    * @returns A cloned Query with the transaction applied
    *
    */
-  public txn(dreamTransaction: DreamTransaction<Dream>) {
+  public txn(dreamTransaction: DreamTransaction<Dream> | null) {
     return this.clone({ transaction: dreamTransaction })
   }
 

--- a/src/dream/internal/associations/createAssociation.ts
+++ b/src/dream/internal/associations/createAssociation.ts
@@ -53,11 +53,8 @@ export default async function createAssociation<
         modifiedOpts[hasAssociation.foreignKeyTypeField()] = dream['stiBaseClassOrOwnClassName']
       }
 
-      if (txn) {
-        hasresult = await associationClass.txn(txn).create(modifiedOpts)
-      } else {
-        hasresult = await associationClass.create(modifiedOpts)
-      }
+      hasresult = await associationClass.txn(txn).create(modifiedOpts)
+
       return hasresult! as NonNullable<AssociationType>
 
     case 'BelongsTo':

--- a/src/dream/internal/findOrCreateBy.ts
+++ b/src/dream/internal/findOrCreateBy.ts
@@ -1,0 +1,40 @@
+import Dream from '../../Dream.js'
+import { CreateOrFindByExtraOptsForDreamInstance, UpdateablePropertiesForClass } from '../../types/dream.js'
+import DreamTransaction from '../DreamTransaction.js'
+
+export default async function findOrCreateBy<T extends typeof Dream>(
+  dreamClass: T,
+  txn: DreamTransaction<InstanceType<T>> | null = null,
+  attributes: UpdateablePropertiesForClass<T>,
+  extraOpts: CreateOrFindByExtraOptsForDreamInstance<InstanceType<T>> = {}
+): Promise<InstanceType<T>> {
+  if (txn) {
+    const existingRecord = await dreamClass
+      .txn(txn)
+      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
+    if (existingRecord) return existingRecord
+
+    const dreamModel = dreamClass.new({
+      ...attributes,
+      ...(extraOpts?.createWith || {}),
+    })
+
+    await dreamModel.txn(txn).save()
+
+    return dreamModel
+  } else {
+    const existingRecord = await dreamClass.findBy(
+      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
+    )
+    if (existingRecord) return existingRecord
+
+    const dreamModel = dreamClass.new({
+      ...attributes,
+      ...(extraOpts?.createWith || {}),
+    })
+
+    await dreamModel.save()
+
+    return dreamModel
+  }
+}

--- a/src/dream/internal/findOrCreateBy.ts
+++ b/src/dream/internal/findOrCreateBy.ts
@@ -1,12 +1,12 @@
 import Dream from '../../Dream.js'
-import { CreateOrFindByExtraOptsForDreamInstance, UpdateablePropertiesForClass } from '../../types/dream.js'
+import { CreateOrFindByExtraOpts, UpdateablePropertiesForClass } from '../../types/dream.js'
 import DreamTransaction from '../DreamTransaction.js'
 
 export default async function findOrCreateBy<T extends typeof Dream>(
   dreamClass: T,
   txn: DreamTransaction<InstanceType<T>> | null = null,
   attributes: UpdateablePropertiesForClass<T>,
-  extraOpts: CreateOrFindByExtraOptsForDreamInstance<InstanceType<T>> = {}
+  extraOpts: CreateOrFindByExtraOpts<T> = {}
 ): Promise<InstanceType<T>> {
   if (txn) {
     const existingRecord = await dreamClass

--- a/src/dream/internal/findOrCreateBy.ts
+++ b/src/dream/internal/findOrCreateBy.ts
@@ -8,16 +8,9 @@ export default async function findOrCreateBy<T extends typeof Dream>(
   attributes: UpdateablePropertiesForClass<T>,
   extraOpts: CreateOrFindByExtraOpts<T> = {}
 ): Promise<InstanceType<T>> {
-  let existingRecord: InstanceType<T> | null
-  if (txn) {
-    existingRecord = await dreamClass
-      .txn(txn)
-      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
-  } else {
-    existingRecord = await dreamClass.findBy(
-      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
-    )
-  }
+  const existingRecord = await dreamClass
+    .txn(txn)
+    .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
 
   if (existingRecord) return existingRecord
 
@@ -26,11 +19,7 @@ export default async function findOrCreateBy<T extends typeof Dream>(
     ...(extraOpts?.createWith || {}),
   })
 
-  if (txn) {
-    await dreamModel.txn(txn).save()
-  } else {
-    await dreamModel.save()
-  }
+  await dreamModel.txn(txn).save()
 
   return dreamModel
 }

--- a/src/dream/internal/saveDream.ts
+++ b/src/dream/internal/saveDream.ts
@@ -12,7 +12,7 @@ export default async function saveDream<DreamInstance extends Dream>(
   dream: DreamInstance,
   txn: DreamTransaction<Dream> | null = null,
   { skipHooks = false }: { skipHooks?: boolean } = {}
-) {
+): Promise<DreamInstance> {
   const db = txn?.kyselyTransaction || _db('primary')
 
   const alreadyPersisted = dream.isPersisted

--- a/src/dream/internal/updateOrCreateBy.ts
+++ b/src/dream/internal/updateOrCreateBy.ts
@@ -24,12 +24,8 @@ export default async function updateOrCreateBy<T extends typeof Dream>(
   const { with: attrs, skipHooks } = extraOpts
 
   if (existingRecord) {
-    if (attrs) {
-      existingRecord.assignAttributes(attrs)
-      return await saveDream(existingRecord, txn, skipHooks ? { skipHooks } : undefined)
-    } else {
-      return existingRecord
-    }
+    existingRecord.assignAttributes(attrs ?? {})
+    return await saveDream(existingRecord, txn, skipHooks ? { skipHooks } : undefined)
   }
 
   if (txn) {

--- a/src/dream/internal/updateOrCreateBy.ts
+++ b/src/dream/internal/updateOrCreateBy.ts
@@ -1,0 +1,52 @@
+import Dream from '../../Dream.js'
+import { UpdateablePropertiesForClass, UpdateOrCreateByExtraOpts } from '../../types/dream.js'
+import DreamTransaction from '../DreamTransaction.js'
+import saveDream from './saveDream.js'
+
+export default async function updateOrCreateBy<T extends typeof Dream>(
+  dreamClass: T,
+  txn: DreamTransaction<InstanceType<T>> | null = null,
+  attributes: UpdateablePropertiesForClass<T>,
+  extraOpts: UpdateOrCreateByExtraOpts<T> = {}
+): Promise<InstanceType<T>> {
+  let existingRecord: InstanceType<T> | null
+
+  if (txn) {
+    existingRecord = await dreamClass
+      .txn(txn)
+      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
+  } else {
+    existingRecord = await dreamClass.findBy(
+      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
+    )
+  }
+
+  const { with: attrs, skipHooks } = extraOpts
+
+  if (existingRecord) {
+    if (attrs) {
+      existingRecord.assignAttributes(attrs)
+      return await saveDream(existingRecord, txn, skipHooks ? { skipHooks } : undefined)
+    } else {
+      return existingRecord
+    }
+  }
+
+  if (txn) {
+    return await dreamClass.txn(txn).create(
+      {
+        ...attributes,
+        ...(extraOpts?.with || {}),
+      },
+      skipHooks ? { skipHooks } : undefined
+    )
+  } else {
+    return await dreamClass.create(
+      {
+        ...attributes,
+        ...(extraOpts?.with || {}),
+      },
+      skipHooks ? { skipHooks } : undefined
+    )
+  }
+}

--- a/src/dream/internal/updateOrCreateBy.ts
+++ b/src/dream/internal/updateOrCreateBy.ts
@@ -9,17 +9,9 @@ export default async function updateOrCreateBy<T extends typeof Dream>(
   attributes: UpdateablePropertiesForClass<T>,
   extraOpts: UpdateOrCreateByExtraOpts<T> = {}
 ): Promise<InstanceType<T>> {
-  let existingRecord: InstanceType<T> | null
-
-  if (txn) {
-    existingRecord = await dreamClass
-      .txn(txn)
-      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
-  } else {
-    existingRecord = await dreamClass.findBy(
-      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
-    )
-  }
+  const existingRecord = await dreamClass
+    .txn(txn)
+    .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
 
   const { with: attrs, skipHooks } = extraOpts
 
@@ -28,21 +20,11 @@ export default async function updateOrCreateBy<T extends typeof Dream>(
     return await saveDream(existingRecord, txn, skipHooks ? { skipHooks } : undefined)
   }
 
-  if (txn) {
-    return await dreamClass.txn(txn).create(
-      {
-        ...attributes,
-        ...(extraOpts?.with || {}),
-      },
-      skipHooks ? { skipHooks } : undefined
-    )
-  } else {
-    return await dreamClass.create(
-      {
-        ...attributes,
-        ...(extraOpts?.with || {}),
-      },
-      skipHooks ? { skipHooks } : undefined
-    )
-  }
+  return await dreamClass.txn(txn).create(
+    {
+      ...attributes,
+      ...(extraOpts?.with || {}),
+    },
+    skipHooks ? { skipHooks } : undefined
+  )
 }

--- a/src/errors/CreateOrUpdateByFailedToCreateAndUpdate.ts
+++ b/src/errors/CreateOrUpdateByFailedToCreateAndUpdate.ts
@@ -1,0 +1,19 @@
+import Dream from '../Dream.js'
+
+export default class CreateOrUpdateByFailedToCreateAndUpdate extends Error {
+  private dreamClass: typeof Dream
+
+  constructor(dreamClass: typeof Dream) {
+    super()
+    this.dreamClass = dreamClass
+  }
+
+  public override get message() {
+    return `
+Failed to create instance of ${this.dreamClass.sanitizedName} and no matching model exists.
+
+The likely cause is that one of the \`createWith\` fields violates
+a uniqueness constraint.
+    `
+  }
+}

--- a/src/errors/CreateOrUpdateByFailedToCreateAndUpdate.ts
+++ b/src/errors/CreateOrUpdateByFailedToCreateAndUpdate.ts
@@ -10,9 +10,9 @@ export default class CreateOrUpdateByFailedToCreateAndUpdate extends Error {
 
   public override get message() {
     return `
-Failed to create instance of ${this.dreamClass.sanitizedName} and no matching model exists.
+Failed to create instance of ${this.dreamClass.sanitizedName} and no matching model exists to update.
 
-The likely cause is that one of the \`createWith\` fields violates
+The likely cause is that one of the \`with\` fields violates
 a uniqueness constraint.
     `
   }

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -318,10 +318,6 @@ export interface CreateOrFindByExtraOpts<T extends typeof Dream> {
   createWith?: UpdateablePropertiesForClass<T>
 }
 
-export interface CreateOrFindByExtraOptsForDreamInstance<T extends Dream> {
-  createWith?: UpdateableProperties<T>
-}
-
 export interface UpdateOrCreateByExtraOpts<T extends typeof Dream> {
   with?: UpdateablePropertiesForClass<T>
   skipHooks?: boolean

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -314,6 +314,19 @@ export type UpdateableProperties<
     (AssociatedModelParam<I> extends never ? object : AssociatedModelParam<I>)
 >
 
+export interface CreateOrFindByExtraOpts<T extends typeof Dream> {
+  createWith?: UpdateablePropertiesForClass<T>
+}
+
+export interface CreateOrFindByExtraOptsForDreamInstance<T extends Dream> {
+  createWith?: UpdateableProperties<T>
+}
+
+export interface UpdateOrCreateByExtraOpts<T extends typeof Dream> {
+  with?: UpdateablePropertiesForClass<T>
+  skipHooks?: boolean
+}
+
 // Model global names and tables
 export type TableNameForGlobalModelName<
   I extends Dream,

--- a/test-app/app/models/Pet.ts
+++ b/test-app/app/models/Pet.ts
@@ -393,4 +393,11 @@ export default class Pet extends ApplicationModel {
       this.name = 'changed by update hook'
     }
   }
+
+  @deco.BeforeCreate()
+  public markRecordCreated() {
+    if (this.name === 'change me') {
+      this.name = 'changed by create hook'
+    }
+  }
 }


### PR DESCRIPTION
This adds the static methods `updateOrCreateBy` and `createOrUpdateBy` to Dream classes, which acts like an upsert but runs hooks.

It also:
- Adds the skip hooks flag to create
- Adds `findOrCreateBy` and `updateOrCreateBy` to the Class Transaction builder