### PR TITLE
Allow `txn` to accept `null` so that we can DRY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/transaction.spec.ts
+++ b/spec/unit/dream/transaction.spec.ts
@@ -17,6 +17,17 @@ describe('ApplicationModel.transaction', () => {
     expect(user.email).toEqual('fred@fishman')
   })
 
+  it('txn can receive null', async () => {
+    const user = await User.create({ email: 'fred@fred', password: 'howyadoin' })
+
+    await Composition.txn(null).create({ user })
+    await user.txn(null).update({ email: 'fred@fishman' })
+
+    expect(await Composition.count()).toEqual(1)
+    await User.find(user.id)
+    expect(user.email).toEqual('fred@fishman')
+  })
+
   it('returns whatever was returned in the underlying callback', async () => {
     const res = await ApplicationModel.transaction(async txn => {
       await User.txn(txn).first()

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -26,6 +26,7 @@ import {
 } from './dream/internal/destroyOptions.js'
 import ensureSTITypeFieldIsSet from './dream/internal/ensureSTITypeFieldIsSet.js'
 import extractAssociationMetadataFromAssociationName from './dream/internal/extractAssociationMetadataFromAssociationName.js'
+import findOrCreateBy from './dream/internal/findOrCreateBy.js'
 import reload from './dream/internal/reload.js'
 import runValidations from './dream/internal/runValidations.js'
 import saveDream from './dream/internal/saveDream.js'
@@ -35,6 +36,7 @@ import {
   DEFAULT_SKIP_HOOKS,
 } from './dream/internal/scopeHelpers.js'
 import undestroyDream from './dream/internal/undestroyDream.js'
+import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
 import LeftJoinLoadBuilder from './dream/LeftJoinLoadBuilder.js'
 import LoadBuilder from './dream/LoadBuilder.js'
 import Query from './dream/Query.js'
@@ -48,6 +50,7 @@ import NonLoadedAssociation from './errors/associations/NonLoadedAssociation.js'
 import CannotCallUndestroyOnANonSoftDeleteModel from './errors/CannotCallUndestroyOnANonSoftDeleteModel.js'
 import ConstructorOnlyForInternalUse from './errors/ConstructorOnlyForInternalUse.js'
 import CreateOrFindByFailedToCreateAndFind from './errors/CreateOrFindByFailedToCreateAndFind.js'
+import CreateOrUpdateByFailedToCreateAndUpdate from './errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
 import GlobalNameNotSet from './errors/dream-app/GlobalNameNotSet.js'
 import DreamMissingRequiredOverride from './errors/DreamMissingRequiredOverride.js'
 import MissingSerializer from './errors/MissingSerializersDefinition.js'
@@ -112,9 +115,6 @@ import {
   VariadicLeftJoinLoadArgs,
   VariadicLoadArgs,
 } from './types/variadic.js'
-import findOrCreateBy from './dream/internal/findOrCreateBy.js'
-import updateOrCreateBy from './dream/internal/updateOrCreateBy.js'
-import CreateOrUpdateByFailedToCreateAndUpdate from './errors/CreateOrUpdateByFailedToCreateAndUpdate.js'
 
 export default class Dream {
   public DB: any
@@ -1664,7 +1664,7 @@ export default class Dream {
    */
   public static txn<T extends typeof Dream, I extends InstanceType<T>>(
     this: T,
-    txn: DreamTransaction<I>
+    txn: DreamTransaction<I> | null
   ): DreamClassTransactionBuilder<T, I> {
     return new DreamClassTransactionBuilder<T, I>(this, txn)
   }
@@ -3830,7 +3830,10 @@ export default class Dream {
    * @param txn - A DreamTransaction instance (collected by calling `ApplicationModel.transaction`)
    * @returns A Query scoped to this model with the transaction applied
    */
-  public txn<I extends Dream>(this: I, txn: DreamTransaction<Dream>): DreamInstanceTransactionBuilder<I> {
+  public txn<I extends Dream>(
+    this: I,
+    txn: DreamTransaction<Dream> | null
+  ): DreamInstanceTransactionBuilder<I> {
     return new DreamInstanceTransactionBuilder<I>(this, txn)
   }
 

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -29,10 +29,10 @@ import {
   VariadicLoadArgs,
 } from '../types/variadic.js'
 import DreamTransaction from './DreamTransaction.js'
-import saveDream from './internal/saveDream.js'
-import Query from './Query.js'
 import findOrCreateBy from './internal/findOrCreateBy.js'
+import saveDream from './internal/saveDream.js'
 import updateOrCreateBy from './internal/updateOrCreateBy.js'
+import Query from './Query.js'
 
 export default class DreamClassTransactionBuilder<
   DreamClass extends typeof Dream,
@@ -47,8 +47,8 @@ export default class DreamClassTransactionBuilder<
    * @param txn - The DreamTransaction instance
    */
   constructor(
-    public dreamClass: DreamClass,
-    public dreamTransaction: DreamTransaction<Dream>
+    private dreamClass: DreamClass,
+    private dreamTransaction: DreamTransaction<Dream> | null
   ) {
     this.dreamInstance = dreamClass.prototype as DreamInstance
   }

--- a/src/dream/DreamInstanceTransactionBuilder.ts
+++ b/src/dream/DreamInstanceTransactionBuilder.ts
@@ -49,19 +49,16 @@ import LoadBuilder from './LoadBuilder.js'
 import Query from './Query.js'
 
 export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream> {
-  public dreamInstance: DreamInstance
-  public dreamTransaction: DreamTransaction<Dream>
-
   /**
    * Constructs a new DreamInstanceTransactionBuilder.
    *
    * @param dreamInstance - The Dream instance to build the transaction for
    * @param txn - The DreamTransaction instance
    */
-  constructor(dreamInstance: DreamInstance, txn: DreamTransaction<Dream>) {
-    this.dreamInstance = dreamInstance
-    this.dreamTransaction = txn
-  }
+  constructor(
+    private dreamInstance: DreamInstance,
+    private dreamTransaction: DreamTransaction<Dream> | null
+  ) {}
 
   /**
    * Loads the requested associations upon execution

--- a/src/dream/LeftJoinLoadBuilder.ts
+++ b/src/dream/LeftJoinLoadBuilder.ts
@@ -12,7 +12,6 @@ import Query from './Query.js'
 
 export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
   private dream: Dream
-  private dreamTransaction: DreamTransaction<any> | undefined
   private query: QueryWithJoinedAssociationsTypeAndNoPreload<Query<DreamInstance>>
 
   /**
@@ -25,7 +24,10 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
    * await user.load('settings').execute()
    * ```
    */
-  constructor(dream: Dream, txn?: DreamTransaction<any>) {
+  constructor(
+    dream: Dream,
+    private dreamTransaction?: DreamTransaction<any> | null
+  ) {
     this.dream = dream['clone']()
 
     // Load queries start from the table corresponding to an instance
@@ -35,7 +37,6 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
     // to other associations (thus the use of `removeAllDefaultScopesExceptOnAssociations`
     // instead of `removeAllDefaultScopes`).
     this.query = (this.dream as any).query()['removeAllDefaultScopesExceptOnAssociations']()
-    this.dreamTransaction = txn
   }
 
   public passthrough<

--- a/src/dream/LoadBuilder.ts
+++ b/src/dream/LoadBuilder.ts
@@ -8,7 +8,6 @@ import Query from './Query.js'
 
 export default class LoadBuilder<DreamInstance extends Dream> {
   private dream: Dream
-  private dreamTransaction: DreamTransaction<any> | undefined
   private query: QueryWithJoinedAssociationsTypeAndNoLeftJoinPreload<Query<DreamInstance>>
 
   /**
@@ -21,7 +20,10 @@ export default class LoadBuilder<DreamInstance extends Dream> {
    * await user.load('settings').execute()
    * ```
    */
-  constructor(dream: Dream, txn?: DreamTransaction<any>) {
+  constructor(
+    dream: Dream,
+    private dreamTransaction?: DreamTransaction<any> | null
+  ) {
     this.dream = dream['clone']()
 
     // Load queries start from the table corresponding to an instance
@@ -31,7 +33,6 @@ export default class LoadBuilder<DreamInstance extends Dream> {
     // to other associations (thus the use of `removeAllDefaultScopesExceptOnAssociations`
     // instead of `removeAllDefaultScopes`).
     this.query = (this.dream as any).query()['removeAllDefaultScopesExceptOnAssociations']()
-    this.dreamTransaction = txn
   }
 
   public passthrough<

--- a/src/dream/Query.ts
+++ b/src/dream/Query.ts
@@ -1493,7 +1493,7 @@ export default class Query<
    * @returns A cloned Query with the transaction applied
    *
    */
-  public txn(dreamTransaction: DreamTransaction<Dream>) {
+  public txn(dreamTransaction: DreamTransaction<Dream> | null) {
     return this.clone({ transaction: dreamTransaction })
   }
 

--- a/src/dream/internal/associations/createAssociation.ts
+++ b/src/dream/internal/associations/createAssociation.ts
@@ -53,11 +53,8 @@ export default async function createAssociation<
         modifiedOpts[hasAssociation.foreignKeyTypeField()] = dream['stiBaseClassOrOwnClassName']
       }
 
-      if (txn) {
-        hasresult = await associationClass.txn(txn).create(modifiedOpts)
-      } else {
-        hasresult = await associationClass.create(modifiedOpts)
-      }
+      hasresult = await associationClass.txn(txn).create(modifiedOpts)
+
       return hasresult! as NonNullable<AssociationType>
 
     case 'BelongsTo':

--- a/src/dream/internal/findOrCreateBy.ts
+++ b/src/dream/internal/findOrCreateBy.ts
@@ -8,16 +8,9 @@ export default async function findOrCreateBy<T extends typeof Dream>(
   attributes: UpdateablePropertiesForClass<T>,
   extraOpts: CreateOrFindByExtraOpts<T> = {}
 ): Promise<InstanceType<T>> {
-  let existingRecord: InstanceType<T> | null
-  if (txn) {
-    existingRecord = await dreamClass
-      .txn(txn)
-      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
-  } else {
-    existingRecord = await dreamClass.findBy(
-      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
-    )
-  }
+  const existingRecord = await dreamClass
+    .txn(txn)
+    .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
 
   if (existingRecord) return existingRecord
 
@@ -26,11 +19,7 @@ export default async function findOrCreateBy<T extends typeof Dream>(
     ...(extraOpts?.createWith || {}),
   })
 
-  if (txn) {
-    await dreamModel.txn(txn).save()
-  } else {
-    await dreamModel.save()
-  }
+  await dreamModel.txn(txn).save()
 
   return dreamModel
 }

--- a/src/dream/internal/updateOrCreateBy.ts
+++ b/src/dream/internal/updateOrCreateBy.ts
@@ -9,17 +9,9 @@ export default async function updateOrCreateBy<T extends typeof Dream>(
   attributes: UpdateablePropertiesForClass<T>,
   extraOpts: UpdateOrCreateByExtraOpts<T> = {}
 ): Promise<InstanceType<T>> {
-  let existingRecord: InstanceType<T> | null
-
-  if (txn) {
-    existingRecord = await dreamClass
-      .txn(txn)
-      .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
-  } else {
-    existingRecord = await dreamClass.findBy(
-      dreamClass['extractAttributesFromUpdateableProperties'](attributes)
-    )
-  }
+  const existingRecord = await dreamClass
+    .txn(txn)
+    .findBy(dreamClass['extractAttributesFromUpdateableProperties'](attributes))
 
   const { with: attrs, skipHooks } = extraOpts
 
@@ -28,21 +20,11 @@ export default async function updateOrCreateBy<T extends typeof Dream>(
     return await saveDream(existingRecord, txn, skipHooks ? { skipHooks } : undefined)
   }
 
-  if (txn) {
-    return await dreamClass.txn(txn).create(
-      {
-        ...attributes,
-        ...(extraOpts?.with || {}),
-      },
-      skipHooks ? { skipHooks } : undefined
-    )
-  } else {
-    return await dreamClass.create(
-      {
-        ...attributes,
-        ...(extraOpts?.with || {}),
-      },
-      skipHooks ? { skipHooks } : undefined
-    )
-  }
+  return await dreamClass.txn(txn).create(
+    {
+      ...attributes,
+      ...(extraOpts?.with || {}),
+    },
+    skipHooks ? { skipHooks } : undefined
+  )
 }


### PR DESCRIPTION
up all places (inside of Dream and externally)
where we may have a Dream or a Dream transaction