### PR TITLE
add support for leveraging dream cb functions in associations

### DIFF
--- a/src/decorators/Decorators.ts
+++ b/src/decorators/Decorators.ts
@@ -13,7 +13,12 @@ import {
   HasOneThroughOptions,
   PolymorphicHasOneOptions,
 } from '../types/associations/hasOne.js'
-import { DreamColumnNames, GlobalModelNameTableMap, SortableOptions } from '../types/dream.js'
+import {
+  DreamColumnNames,
+  GlobalModelIdentifier,
+  SortableOptions,
+  TableNameForGlobalModelName,
+} from '../types/dream.js'
 import { AfterHookOpts, BeforeHookOpts } from '../types/lifecycle.js'
 import { OpenapiSchemaBodyShorthand, OpenapiShorthandPrimitiveTypes } from '../types/openapi.js'
 import { ValidationType } from '../types/validation.js'
@@ -41,23 +46,21 @@ import Scope from './static-method/Scope.js'
 
 export default class Decorators<TD extends typeof Dream, T extends Dream = InstanceType<TD>> {
   public BelongsTo<
-    const AssociationGlobalNameOrNames extends
-      | keyof GlobalModelNameTableMap<T>
-      | (keyof GlobalModelNameTableMap<T>)[],
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalNameOrNames,
-    options?: NonPolymorphicBelongsToOptions<T, AssociationGlobalNameOrNames>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: NonPolymorphicBelongsToOptions<T, AssociationTableNameOrNames>
   ): any
 
   public BelongsTo<
-    const AssociationGlobalNameOrNames extends
-      | keyof GlobalModelNameTableMap<T>
-      | (keyof GlobalModelNameTableMap<T>)[],
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalNameOrNames,
-    options?: PolymorphicBelongsToOptions<T, AssociationGlobalNameOrNames>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: PolymorphicBelongsToOptions<T, AssociationTableNameOrNames>
   ): any
 
   /**
@@ -85,32 +88,43 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    * @returns A BelongsTo decorator
    */
   public BelongsTo<
-    const AssociationGlobalNameOrNames extends
-      | keyof GlobalModelNameTableMap<T>
-      | (keyof GlobalModelNameTableMap<T>)[],
-  >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalNameOrNames, options: unknown = {}) {
-    return BelongsTo<T, AssociationGlobalNameOrNames>(globalAssociationNameOrNames, options as any)
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}) {
+    return BelongsTo<T, AssociationGlobalId, AssociationTableNameOrNames>(
+      globalAssociationNameOrNames,
+      options as any
+    )
   }
 
   ///////////
   // HasMany
   ///////////
-  public HasMany<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasMany<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: HasManyOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: HasManyOptions<T, AssociationTableName>
   ): any
 
-  public HasMany<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasMany<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: HasManyThroughOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: HasManyThroughOptions<T, AssociationTableName>
   ): any
 
-  public HasMany<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasMany<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: PolymorphicHasManyOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: PolymorphicHasManyOptions<T, AssociationTableName>
   ): any
 
   /**
@@ -136,12 +150,11 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    * @param options - the options you want to use to apply to this association
    * @returns A HasMany decorator
    */
-  public HasMany<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
-    this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options: unknown = {}
-  ) {
-    return HasMany<T, AssociationGlobalName>(globalAssociationNameOrNames, options as any)
+  public HasMany<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}) {
+    return HasMany<T, AssociationGlobalId, AssociationTableName>(globalAssociationNameOrNames, options as any)
   }
   ///////////////
   // end: HasMany
@@ -150,22 +163,31 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
   ///////////
   // HasOne
   ///////////
-  public HasOne<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasOne<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: HasOneOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: HasOneOptions<T, AssociationTableName>
   ): any
 
-  public HasOne<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasOne<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: HasOneThroughOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: HasOneThroughOptions<T, AssociationTableName>
   ): any
 
-  public HasOne<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
+  public HasOne<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(
     this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options?: PolymorphicHasOneOptions<T, AssociationGlobalName>
+    globalAssociationNameOrNames: AssociationGlobalId,
+    options?: PolymorphicHasOneOptions<T, AssociationTableName>
   ): any
 
   /**
@@ -190,12 +212,11 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    * @param options - The options you want to use to apply to this association
    * @returns A HasOne decorator
    */
-  public HasOne<const AssociationGlobalName extends keyof GlobalModelNameTableMap<T>>(
-    this: Decorators<TD>,
-    globalAssociationNameOrNames: AssociationGlobalName,
-    options: unknown = {}
-  ): any {
-    return HasOne<T, AssociationGlobalName>(globalAssociationNameOrNames, options as any)
+  public HasOne<
+    const AssociationGlobalId extends GlobalModelIdentifier<T>,
+    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+  >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}): any {
+    return HasOne<T, AssociationGlobalId, AssociationTableName>(globalAssociationNameOrNames, options as any)
   }
   //////////////
   // end: HasOne

--- a/src/decorators/Decorators.ts
+++ b/src/decorators/Decorators.ts
@@ -17,7 +17,7 @@ import {
   DreamColumnNames,
   GlobalModelIdentifier,
   SortableOptions,
-  TableNameForGlobalModelName,
+  TableNameForGlobalModelIdentifier,
 } from '../types/dream.js'
 import { AfterHookOpts, BeforeHookOpts } from '../types/lifecycle.js'
 import { OpenapiSchemaBodyShorthand, OpenapiShorthandPrimitiveTypes } from '../types/openapi.js'
@@ -47,7 +47,7 @@ import Scope from './static-method/Scope.js'
 export default class Decorators<TD extends typeof Dream, T extends Dream = InstanceType<TD>> {
   public BelongsTo<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -56,7 +56,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
 
   public BelongsTo<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -89,7 +89,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    */
   public BelongsTo<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableNameOrNames extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableNameOrNames extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}) {
     return BelongsTo<T, AssociationGlobalId, AssociationTableNameOrNames>(
       globalAssociationNameOrNames,
@@ -102,7 +102,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
   ///////////
   public HasMany<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -111,7 +111,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
 
   public HasMany<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -120,7 +120,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
 
   public HasMany<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -152,7 +152,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    */
   public HasMany<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}) {
     return HasMany<T, AssociationGlobalId, AssociationTableName>(globalAssociationNameOrNames, options as any)
   }
@@ -165,7 +165,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
   ///////////
   public HasOne<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -174,7 +174,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
 
   public HasOne<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -183,7 +183,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
 
   public HasOne<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(
     this: Decorators<TD>,
     globalAssociationNameOrNames: AssociationGlobalId,
@@ -214,7 +214,7 @@ export default class Decorators<TD extends typeof Dream, T extends Dream = Insta
    */
   public HasOne<
     const AssociationGlobalId extends GlobalModelIdentifier<T>,
-    AssociationTableName extends TableNameForGlobalModelName<T, AssociationGlobalId>,
+    AssociationTableName extends TableNameForGlobalModelIdentifier<T, AssociationGlobalId>,
   >(this: Decorators<TD>, globalAssociationNameOrNames: AssociationGlobalId, options: unknown = {}): any {
     return HasOne<T, AssociationGlobalId, AssociationTableName>(globalAssociationNameOrNames, options as any)
   }

--- a/src/decorators/class/ReplicaSafe.ts
+++ b/src/decorators/class/ReplicaSafe.ts
@@ -1,12 +1,15 @@
+import DreamImporter from '../../dream-app/helpers/DreamImporter.js'
 import Dream from '../../Dream.js'
 import StiChildIncompatibleWithReplicaSafeDecorator from '../../errors/sti/StiChildIncompatibleWithReplicaSafeDecorator.js'
 
 export default function ReplicaSafe(): ClassDecorator {
   return function (target: any) {
-    const dreamClass = target as typeof Dream
+    DreamImporter.addImportHook(() => {
+      const dreamClass = target as typeof Dream
 
-    if (dreamClass['isSTIChild']) throw new StiChildIncompatibleWithReplicaSafeDecorator(dreamClass)
+      if (dreamClass['isSTIChild']) throw new StiChildIncompatibleWithReplicaSafeDecorator(dreamClass)
 
-    dreamClass['replicaSafe'] = true
+      dreamClass['replicaSafe'] = true
+    })
   }
 }

--- a/src/decorators/class/STI.ts
+++ b/src/decorators/class/STI.ts
@@ -36,8 +36,8 @@ export default function STI(dreamCb: () => typeof Dream, { value }: { value?: st
       ;(stiChildClass as any)[STI_SCOPE_NAME] = function (query: any) {
         return query.where({ type: stiChildClass['sti'].value })
       }
-    })
 
-    scopeImplementation(stiChildClass, STI_SCOPE_NAME, { default: true })
+      scopeImplementation(stiChildClass, STI_SCOPE_NAME, { default: true })
+    })
   }
 }

--- a/src/decorators/class/STI.ts
+++ b/src/decorators/class/STI.ts
@@ -1,6 +1,6 @@
 import DreamImporter from '../../dream-app/helpers/DreamImporter.js'
 import Dream from '../../Dream.js'
-import StiChildCannotDefineNewAssociations from '../../errors/sti/StiChildCannotDefineNewAssociations.js'
+// import StiChildCannotDefineNewAssociations from '../../errors/sti/StiChildCannotDefineNewAssociations.js'
 import StiChildIncompatibleWithReplicaSafeDecorator from '../../errors/sti/StiChildIncompatibleWithReplicaSafeDecorator.js'
 import StiChildIncompatibleWithSoftDeleteDecorator from '../../errors/sti/StiChildIncompatibleWithSoftDeleteDecorator.js'
 import { scopeImplementation } from '../static-method/Scope.js'
@@ -15,8 +15,8 @@ export default function STI(dreamCb: () => typeof Dream, { value }: { value?: st
       const dreamClass = dreamCb()
       const baseClass = dreamClass['sti'].baseClass || dreamClass
 
-      if (Object.getOwnPropertyDescriptor(stiChildClass, 'associationMetadataByType'))
-        throw new StiChildCannotDefineNewAssociations(baseClass, stiChildClass)
+      // if (Object.getOwnPropertyDescriptor(stiChildClass, 'associationMetadataByType'))
+      //   throw new StiChildCannotDefineNewAssociations(baseClass, stiChildClass)
 
       if (Object.getOwnPropertyDescriptor(stiChildClass, 'replicaSafe'))
         throw new StiChildIncompatibleWithReplicaSafeDecorator(stiChildClass)

--- a/src/decorators/class/SoftDelete.ts
+++ b/src/decorators/class/SoftDelete.ts
@@ -43,10 +43,8 @@ export const SOFT_DELETE_SCOPE_NAME = 'dream:SoftDelete'
  */
 export default function SoftDelete(): ClassDecorator {
   return function (target: any) {
-    const dreamCb = target as () => typeof Dream
-
     DreamImporter.addImportHook(() => {
-      const dreamClass = dreamCb()
+      const dreamClass = target as typeof Dream
 
       if (dreamClass['isSTIChild']) throw new StiChildIncompatibleWithSoftDeleteDecorator(dreamClass)
 
@@ -56,7 +54,7 @@ export default function SoftDelete(): ClassDecorator {
         return query.where({ [dreamClass.prototype.deletedAtField]: null } as any)
       }
 
-      scopeImplementation(dreamClass, SOFT_DELETE_SCOPE_NAME, { default: true })
+      scopeImplementation(target, SOFT_DELETE_SCOPE_NAME, { default: true })
     })
   }
 }

--- a/src/decorators/field/association/BelongsTo.ts
+++ b/src/decorators/field/association/BelongsTo.ts
@@ -5,7 +5,7 @@ import {
   NonPolymorphicBelongsToOptions,
   PolymorphicBelongsToOptions,
 } from '../../../types/associations/belongsTo.js'
-import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelIdentifier } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import { validatesImplementation } from '../validation/Validates.js'
 import {
@@ -19,7 +19,7 @@ import {
 export default function BelongsTo<
   BaseInstance extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<BaseInstance>,
-  AssociationTableNameOrNames extends TableNameForGlobalModelName<BaseInstance, AssociationGlobalId>,
+  AssociationTableNameOrNames extends TableNameForGlobalModelIdentifier<BaseInstance, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: NonPolymorphicBelongsToOptions<BaseInstance, AssociationTableNameOrNames>
@@ -28,7 +28,7 @@ export default function BelongsTo<
 export default function BelongsTo<
   BaseInstance extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<BaseInstance>,
-  AssociationTableNameOrNames extends TableNameForGlobalModelName<BaseInstance, AssociationGlobalId>,
+  AssociationTableNameOrNames extends TableNameForGlobalModelIdentifier<BaseInstance, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: PolymorphicBelongsToOptions<BaseInstance, AssociationTableNameOrNames>

--- a/src/decorators/field/association/BelongsTo.ts
+++ b/src/decorators/field/association/BelongsTo.ts
@@ -5,7 +5,7 @@ import {
   NonPolymorphicBelongsToOptions,
   PolymorphicBelongsToOptions,
 } from '../../../types/associations/belongsTo.js'
-import { GlobalModelNameTableMap } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import { validatesImplementation } from '../validation/Validates.js'
 import {
@@ -18,22 +18,20 @@ import {
 
 export default function BelongsTo<
   BaseInstance extends Dream,
-  AssociationGlobalNameOrNames extends
-    | keyof GlobalModelNameTableMap<BaseInstance>
-    | (keyof GlobalModelNameTableMap<BaseInstance>)[],
+  const AssociationGlobalId extends GlobalModelIdentifier<BaseInstance>,
+  AssociationTableNameOrNames extends TableNameForGlobalModelName<BaseInstance, AssociationGlobalId>,
 >(
-  globalAssociationNameOrNames: AssociationGlobalNameOrNames,
-  opts?: NonPolymorphicBelongsToOptions<BaseInstance, AssociationGlobalNameOrNames>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: NonPolymorphicBelongsToOptions<BaseInstance, AssociationTableNameOrNames>
 ): any
 
 export default function BelongsTo<
   BaseInstance extends Dream,
-  AssociationGlobalNameOrNames extends
-    | keyof GlobalModelNameTableMap<BaseInstance>
-    | (keyof GlobalModelNameTableMap<BaseInstance>)[],
+  const AssociationGlobalId extends GlobalModelIdentifier<BaseInstance>,
+  AssociationTableNameOrNames extends TableNameForGlobalModelName<BaseInstance, AssociationGlobalId>,
 >(
-  globalAssociationNameOrNames: AssociationGlobalNameOrNames,
-  opts?: PolymorphicBelongsToOptions<BaseInstance, AssociationGlobalNameOrNames>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: PolymorphicBelongsToOptions<BaseInstance, AssociationTableNameOrNames>
 ): any
 
 /**

--- a/src/decorators/field/association/HasMany.ts
+++ b/src/decorators/field/association/HasMany.ts
@@ -6,7 +6,7 @@ import {
   HasManyThroughOptions,
   PolymorphicHasManyOptions,
 } from '../../../types/associations/hasMany.js'
-import { GlobalModelNameTableMap } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import {
   applyGetterAndSetter,
@@ -18,27 +18,27 @@ import {
 } from './shared.js'
 
 export default function HasMany<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+>(globalAssociationNameOrNames: AssociationGlobalId, opts?: HasManyOptions<I, AssociationTableName>): any
+
+export default function HasMany<
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
 >(
-  globalAssociationNameOrNames: AssociationGlobalName,
-  opts?: HasManyOptions<BaseInstance, AssociationGlobalName>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: HasManyThroughOptions<I, AssociationTableName>
 ): any
 
 export default function HasMany<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
 >(
-  globalAssociationNameOrNames: AssociationGlobalName,
-  opts?: HasManyThroughOptions<BaseInstance, AssociationGlobalName>
-): any
-
-export default function HasMany<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
->(
-  globalAssociationNameOrNames: AssociationGlobalName,
-  opts?: PolymorphicHasManyOptions<BaseInstance, AssociationGlobalName>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: PolymorphicHasManyOptions<I, AssociationTableName>
 ): any
 
 /**
@@ -75,8 +75,8 @@ export default function HasMany<
  * @param opts.through - If passed, this association will travel through another association.
  * @param opts.withoutDefaultScopes - A list of default scopes to bypass when loading this association
  */
-export default function HasMany<BaseInstance extends Dream, AssociationGlobalNameOrNames>(
-  globalAssociationNameOrNames: AssociationGlobalNameOrNames,
+export default function HasMany<BaseInstance extends Dream, AssociationTableNameOrNames>(
+  globalAssociationNameOrNames: AssociationTableNameOrNames,
   opts: unknown = {}
 ): any {
   const {

--- a/src/decorators/field/association/HasMany.ts
+++ b/src/decorators/field/association/HasMany.ts
@@ -6,7 +6,7 @@ import {
   HasManyThroughOptions,
   PolymorphicHasManyOptions,
 } from '../../../types/associations/hasMany.js'
-import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelIdentifier } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import {
   applyGetterAndSetter,
@@ -20,13 +20,13 @@ import {
 export default function HasMany<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(globalAssociationNameOrNames: AssociationGlobalId, opts?: HasManyOptions<I, AssociationTableName>): any
 
 export default function HasMany<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: HasManyThroughOptions<I, AssociationTableName>
@@ -35,7 +35,7 @@ export default function HasMany<
 export default function HasMany<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: PolymorphicHasManyOptions<I, AssociationTableName>

--- a/src/decorators/field/association/HasOne.ts
+++ b/src/decorators/field/association/HasOne.ts
@@ -6,7 +6,7 @@ import {
   HasOneThroughOptions,
   PolymorphicHasOneOptions,
 } from '../../../types/associations/hasOne.js'
-import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelIdentifier } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import {
   applyGetterAndSetter,
@@ -20,13 +20,13 @@ import {
 export default function HasOne<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(globalAssociationName: AssociationGlobalId, opts?: HasOneOptions<I, AssociationTableName>): any
 
 export default function HasOne<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: HasOneThroughOptions<I, AssociationTableName>
@@ -35,7 +35,7 @@ export default function HasOne<
 export default function HasOne<
   I extends Dream,
   const AssociationGlobalId extends GlobalModelIdentifier<I>,
-  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+  AssociationTableName extends TableNameForGlobalModelIdentifier<I, AssociationGlobalId>,
 >(
   globalAssociationNameOrNames: AssociationGlobalId,
   opts?: PolymorphicHasOneOptions<I, AssociationTableName>

--- a/src/decorators/field/association/HasOne.ts
+++ b/src/decorators/field/association/HasOne.ts
@@ -6,7 +6,7 @@ import {
   HasOneThroughOptions,
   PolymorphicHasOneOptions,
 } from '../../../types/associations/hasOne.js'
-import { GlobalModelNameTableMap } from '../../../types/dream.js'
+import { GlobalModelIdentifier, TableNameForGlobalModelName } from '../../../types/dream.js'
 import { DecoratorContext } from '../../DecoratorContextType.js'
 import {
   applyGetterAndSetter,
@@ -18,27 +18,27 @@ import {
 } from './shared.js'
 
 export default function HasOne<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
+>(globalAssociationName: AssociationGlobalId, opts?: HasOneOptions<I, AssociationTableName>): any
+
+export default function HasOne<
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
 >(
-  globalAssociationName: AssociationGlobalName,
-  opts?: HasOneOptions<BaseInstance, AssociationGlobalName>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: HasOneThroughOptions<I, AssociationTableName>
 ): any
 
 export default function HasOne<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
+  I extends Dream,
+  const AssociationGlobalId extends GlobalModelIdentifier<I>,
+  AssociationTableName extends TableNameForGlobalModelName<I, AssociationGlobalId>,
 >(
-  globalAssociationNameOrNames: AssociationGlobalName,
-  opts?: HasOneThroughOptions<BaseInstance, AssociationGlobalName>
-): any
-
-export default function HasOne<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
->(
-  globalAssociationNameOrNames: AssociationGlobalName,
-  opts?: PolymorphicHasOneOptions<BaseInstance, AssociationGlobalName>
+  globalAssociationNameOrNames: AssociationGlobalId,
+  opts?: PolymorphicHasOneOptions<I, AssociationTableName>
 ): any
 
 /**
@@ -73,8 +73,8 @@ export default function HasOne<
  * @param opts.through - If passed, this association will travel through another association.
  * @param opts.withoutDefaultScopes - A list of default scopes to bypass when loading this association
  */
-export default function HasOne<BaseInstance extends Dream, AssociationGlobalNameOrNames>(
-  globalAssociationNameOrNames: AssociationGlobalNameOrNames,
+export default function HasOne<BaseInstance extends Dream, AssociationTableNameOrNames>(
+  globalAssociationNameOrNames: AssociationTableNameOrNames,
   opts: unknown = {}
 ): any {
   const {

--- a/src/decorators/static-method/Scope.ts
+++ b/src/decorators/static-method/Scope.ts
@@ -1,3 +1,4 @@
+import DreamImporter from '../../dream-app/helpers/DreamImporter.js'
 import Dream from '../../Dream.js'
 import { DecoratorContext } from '../DecoratorContextType.js'
 
@@ -7,14 +8,16 @@ export default function Scope(
   } = {}
 ): any {
   return function (_: any, context: DecoratorContext & { static: true }) {
-    const key = context.name
+    DreamImporter.addImportHook(() => {
+      const key = context.name
 
-    context.addInitializer(function (this: typeof Dream) {
-      // this is already a typeof Dream here, because scopes
-      // can only be set on static methods
-      const t: typeof Dream = this
+      context.addInitializer(function (this: typeof Dream) {
+        // this is already a typeof Dream here, because scopes
+        // can only be set on static methods
+        const t: typeof Dream = this
 
-      scopeImplementation(t, key, opts)
+        scopeImplementation(t, key, opts)
+      })
     })
   }
 }

--- a/src/decorators/static-method/Scope.ts
+++ b/src/decorators/static-method/Scope.ts
@@ -1,4 +1,3 @@
-import DreamImporter from '../../dream-app/helpers/DreamImporter.js'
 import Dream from '../../Dream.js'
 import { DecoratorContext } from '../DecoratorContextType.js'
 
@@ -8,16 +7,14 @@ export default function Scope(
   } = {}
 ): any {
   return function (_: any, context: DecoratorContext & { static: true }) {
-    DreamImporter.addImportHook(() => {
-      const key = context.name
+    const key = context.name
 
-      context.addInitializer(function (this: typeof Dream) {
-        // this is already a typeof Dream here, because scopes
-        // can only be set on static methods
-        const t: typeof Dream = this
+    context.addInitializer(function (this: typeof Dream) {
+      // this is already a typeof Dream here, because scopes
+      // can only be set on static methods
+      const t: typeof Dream = this
 
-        scopeImplementation(t, key, opts)
-      })
+      scopeImplementation(t, key, opts)
     })
   }
 }

--- a/src/dream-app/helpers/DreamImporter.ts
+++ b/src/dream-app/helpers/DreamImporter.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path'
 import Dream from '../../Dream.js'
 import { DreamModelSerializerType, SimpleObjectSerializerType } from '../../types/serializer.js'
 
+let importDecoratorHooks: (() => void)[] = []
+
 export default class DreamImporter {
   public static async ls(dir: string): Promise<string[]> {
     try {
@@ -24,6 +26,21 @@ export default class DreamImporter {
       if ((err as any).code === 'ENOENT') return []
       throw err
     }
+  }
+
+  public static addImportHook(cb: () => void) {
+    importDecoratorHooks.push(cb)
+  }
+
+  public static runAndClearHooks() {
+    importDecoratorHooks.forEach(cb => {
+      cb()
+    })
+    this.clearImportHooks()
+  }
+
+  public static clearImportHooks() {
+    importDecoratorHooks = []
   }
 
   public static async importDreams(

--- a/src/dream-app/helpers/importers/importModels.ts
+++ b/src/dream-app/helpers/importers/importModels.ts
@@ -12,7 +12,6 @@ export default async function importModels(
   if (_models) return _models
 
   const modelClasses = await DreamImporter.importDreams(modelsPath, modelImportCb)
-  DreamImporter.runAndClearHooks()
 
   /**
    * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)
@@ -67,6 +66,8 @@ export default async function importModels(
    * to only apply static values once, on boot, `globallyInitializingDecorators` is set to true on Dream, and all Dream models are instantiated.
    */
   Dream['globallyInitializingDecorators'] = false
+
+  DreamImporter.runAndClearHooks()
 
   return _models
 }

--- a/src/dream-app/helpers/importers/importModels.ts
+++ b/src/dream-app/helpers/importers/importModels.ts
@@ -12,6 +12,7 @@ export default async function importModels(
   if (_models) return _models
 
   const modelClasses = await DreamImporter.importDreams(modelsPath, modelImportCb)
+  DreamImporter.runAndClearHooks()
 
   /**
    * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)

--- a/src/dream-app/helpers/lookupModelByGlobalNameOrNames.ts
+++ b/src/dream-app/helpers/lookupModelByGlobalNameOrNames.ts
@@ -1,7 +1,15 @@
+import Dream from '../../Dream.js'
 import compact from '../../helpers/compact.js'
 import lookupModelByGlobalName from './lookupModelByGlobalName.js'
 
-export default function lookupModelByGlobalNameOrNames(globalName: string | string[]) {
-  if (Array.isArray(globalName)) return compact(globalName.map(name => lookupModelByGlobalName(name)))
-  return lookupModelByGlobalName(globalName)
+export default function lookupModelByGlobalNameOrNames(
+  globalName: string | string[] | (() => typeof Dream) | (() => (typeof Dream)[])
+) {
+  if (typeof globalName === 'function') {
+    const modelOrModels = globalName()
+    return modelOrModels
+  } else {
+    if (Array.isArray(globalName)) return compact(globalName.map(name => lookupModelByGlobalName(name)))
+    return lookupModelByGlobalName(globalName)
+  }
 }

--- a/src/types/associations/belongsTo.ts
+++ b/src/types/associations/belongsTo.ts
@@ -1,13 +1,6 @@
 import Dream from '../../Dream.js'
 import { AssociationTableNames } from '../db.js'
-import {
-  DefaultScopeName,
-  DefaultScopeNameForTable,
-  DreamColumnNames,
-  GlobalModelNames,
-  TableColumnNames,
-  TableNameForGlobalModelName,
-} from '../dream.js'
+import { DefaultScopeName, DefaultScopeNameForTable, DreamColumnNames, TableColumnNames } from '../dream.js'
 
 export interface BelongsToStatement<
   BaseInstance extends Dream,
@@ -32,19 +25,7 @@ export interface BelongsToStatement<
 
 export interface NonPolymorphicBelongsToOptions<
   BaseInstance extends Dream,
-  AssociationGlobalNameOrNames extends
-    | GlobalModelNames<BaseInstance>
-    | readonly GlobalModelNames<BaseInstance>[],
-  AssociationGlobalName = AssociationGlobalNameOrNames extends Readonly<any[]>
-    ? AssociationGlobalNameOrNames[0] & string
-    : AssociationGlobalNameOrNames & string,
-  AssociationTableName extends AssociationTableNames<BaseInstance['DB'], BaseInstance['schema']> &
-    keyof BaseInstance['DB'] = TableNameForGlobalModelName<
-    BaseInstance,
-    AssociationGlobalName & GlobalModelNames<BaseInstance>
-  > &
-    AssociationTableNames<BaseInstance['DB'], BaseInstance['schema']> &
-    keyof BaseInstance['DB'],
+  AssociationTableName extends keyof BaseInstance['DB'],
 > {
   foreignKey?: DreamColumnNames<BaseInstance>
   primaryKeyOverride?: TableColumnNames<BaseInstance['DB'], AssociationTableName> | null
@@ -54,19 +35,7 @@ export interface NonPolymorphicBelongsToOptions<
 
 export interface PolymorphicBelongsToOptions<
   BaseInstance extends Dream,
-  AssociationGlobalNameOrNames extends
-    | GlobalModelNames<BaseInstance>
-    | readonly GlobalModelNames<BaseInstance>[],
-  AssociationGlobalName = AssociationGlobalNameOrNames extends Readonly<any[]>
-    ? AssociationGlobalNameOrNames[0] & string
-    : AssociationGlobalNameOrNames & string,
-  AssociationTableName extends AssociationTableNames<BaseInstance['DB'], BaseInstance['schema']> &
-    keyof BaseInstance['DB'] = TableNameForGlobalModelName<
-    BaseInstance,
-    AssociationGlobalName & GlobalModelNames<BaseInstance>
-  > &
-    AssociationTableNames<BaseInstance['DB'], BaseInstance['schema']> &
-    keyof BaseInstance['DB'],
+  AssociationTableName extends keyof BaseInstance['DB'],
 > {
   foreignKey: DreamColumnNames<BaseInstance>
   primaryKeyOverride?: TableColumnNames<BaseInstance['DB'], AssociationTableName> | null

--- a/src/types/associations/hasMany.ts
+++ b/src/types/associations/hasMany.ts
@@ -1,11 +1,6 @@
 import Dream from '../../Dream.js'
 import { AssociationTableNames } from '../db.js'
-import {
-  GlobalModelNames,
-  GlobalModelNameTableMap,
-  TableColumnNames,
-  TableNameForGlobalModelName,
-} from '../dream.js'
+import { GlobalModelNameTableMap, TableColumnNames } from '../dream.js'
 import {
   HasOptions,
   HasStatement,
@@ -25,16 +20,7 @@ export type HasManyStatement<
 }
 interface HasManyOnlyOptions<
   BaseInstance extends Dream,
-  AssociationGlobalNameOrNames extends
-    | GlobalModelNames<BaseInstance>
-    | readonly GlobalModelNames<BaseInstance>[],
-  AssociationGlobalName = AssociationGlobalNameOrNames extends any[]
-    ? AssociationGlobalNameOrNames[0] & string
-    : AssociationGlobalNameOrNames & string,
-  AssociationTableName = TableNameForGlobalModelName<
-    BaseInstance,
-    AssociationGlobalName & GlobalModelNames<BaseInstance>
-  >,
+  AssociationTableName extends keyof BaseInstance['DB'],
 > {
   distinct?:
     | TableColumnNames<
@@ -69,12 +55,12 @@ export type HasManyOptions<
 
 export type PolymorphicHasManyOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = PolymorphicHasOptions<BaseInstance, AssociationGlobalName> &
-  HasManyOnlyOptions<BaseInstance, AssociationGlobalName>
+  AssociationTableName extends keyof BaseInstance['DB'],
+> = PolymorphicHasOptions<BaseInstance, AssociationTableName> &
+  HasManyOnlyOptions<BaseInstance, AssociationTableName>
 
 export type HasManyThroughOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = HasThroughOptions<BaseInstance, AssociationGlobalName> &
-  HasManyOnlyOptions<BaseInstance, AssociationGlobalName>
+  AssociationTableName extends keyof BaseInstance['DB'],
+> = HasThroughOptions<BaseInstance, AssociationTableName> &
+  HasManyOnlyOptions<BaseInstance, AssociationTableName>

--- a/src/types/associations/hasOne.ts
+++ b/src/types/associations/hasOne.ts
@@ -12,8 +12,8 @@ export type HasOneStatement<
 
 export type HasOneOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = HasOptions<BaseInstance, AssociationGlobalName>
+  AssociationTableName extends keyof BaseInstance['DB'],
+> = HasOptions<BaseInstance, AssociationTableName>
 
 export type PolymorphicHasOneOptions<
   BaseInstance extends Dream,

--- a/src/types/associations/shared.ts
+++ b/src/types/associations/shared.ts
@@ -16,13 +16,11 @@ import {
   DefaultScopeNameForTable,
   DreamBelongsToAssociationMetadata,
   DreamColumnNames,
-  GlobalModelNameTableMap,
   IdType,
   OrderDir,
   TableColumnEnumTypeArray,
   TableColumnNames,
   TableColumnType,
-  TableNameForGlobalModelName,
   TrigramOperator,
 } from '../dream.js'
 import { Inc, MergeUnionOfRecordTypes, ReadonlyTail, UnionToIntersection } from '../utils.js'
@@ -321,15 +319,9 @@ export interface HasStatement<
   withoutDefaultScopes?: DefaultScopeName<BaseInstance>[]
 }
 
-interface HasOptionsBase<
-  BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-  AssociationTableName = TableNameForGlobalModelName<
-    BaseInstance,
-    AssociationGlobalName & keyof GlobalModelNameTableMap<BaseInstance>
-  >,
-> {
+interface HasOptionsBase<BaseInstance extends Dream, AssociationTableName extends keyof Dream['DB']> {
   dependent?: DependentOptions
+  ham?: AssociationTableName
   foreignKey?: TableColumnNames<BaseInstance['DB'], AssociationTableName & keyof BaseInstance['DB']>
 
   and?: OnStatementForAssociationDefinition<
@@ -399,19 +391,19 @@ type ThroughOnlyOptions = 'through' | 'source' | 'preloadThroughColumns'
 
 export type HasOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = Omit<HasOptionsBase<BaseInstance, AssociationGlobalName>, ThroughOnlyOptions | PolymorphicOption>
+  AssociationTableName extends keyof BaseInstance['DB'],
+> = Omit<HasOptionsBase<BaseInstance, AssociationTableName>, ThroughOnlyOptions | PolymorphicOption>
 
 export type PolymorphicHasOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = HasOptionsBase<BaseInstance, AssociationGlobalName> &
-  Required<Pick<HasOptionsBase<BaseInstance, AssociationGlobalName>, PolymorphicOption | ForeignKeyOption>>
+  AssociationTableName extends keyof BaseInstance['DB'],
+> = HasOptionsBase<BaseInstance, AssociationTableName> &
+  Required<Pick<HasOptionsBase<BaseInstance, AssociationTableName>, PolymorphicOption | ForeignKeyOption>>
 
 export type HasThroughOptions<
   BaseInstance extends Dream,
-  AssociationGlobalName extends keyof GlobalModelNameTableMap<BaseInstance>,
-> = Omit<HasOptionsBase<BaseInstance, AssociationGlobalName>, ThroughIncompatibleOptions>
+  AssociationTableName extends BaseInstance['DB'],
+> = Omit<HasOptionsBase<BaseInstance, AssociationTableName>, ThroughIncompatibleOptions>
 
 export interface AssociationStatementsMap {
   belongsTo: readonly BelongsToStatement<any, any, any, any>[] | BelongsToStatement<any, any, any, any>[]

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -316,12 +316,29 @@ export interface UpdateOrCreateByExtraOpts<T extends typeof Dream> {
 }
 
 // Model global names and tables
-export type TableNameForGlobalModelName<
-  I extends Dream,
-  GMN extends keyof GlobalModelNameTableMap<I>,
-> = GlobalModelNameTableMap<I>[GMN]
+export type TableNameForGlobalModelName<I extends Dream, GMN> = GMN extends keyof GlobalModelNameTableMap<I>
+  ? GlobalModelNameTableMap<I>[GMN]
+  : GMN extends (keyof GlobalModelNameTableMap<I>)[]
+    ? GlobalModelNameTableMap<I>[GMN[number]]
+    : GMN extends () => typeof Dream
+      ? ModelFromModelCb<GMN>['prototype']['table']
+      : GMN extends () => (typeof Dream)[]
+        ? ModelFromModelCb<GMN>['prototype']['table']
+        : never
+
+type ModelFromModelCb<ModelCb> = ModelCb extends () => typeof Dream
+  ? ReturnType<ModelCb>
+  : ModelCb extends () => (typeof Dream)[]
+    ? ReturnType<ModelCb>[number]
+    : never
 
 export type GlobalModelNames<I extends Dream> = keyof GlobalModelNameTableMap<I>
+
+export type GlobalModelIdentifier<I extends Dream> =
+  | GlobalModelNames<I>
+  | GlobalModelNames<I>[]
+  | (() => typeof Dream)
+  | (() => (typeof Dream)[])
 
 export type GlobalModelNameTableMap<
   I extends Dream,

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -316,7 +316,10 @@ export interface UpdateOrCreateByExtraOpts<T extends typeof Dream> {
 }
 
 // Model global names and tables
-export type TableNameForGlobalModelName<I extends Dream, GMN> = GMN extends keyof GlobalModelNameTableMap<I>
+export type TableNameForGlobalModelIdentifier<
+  I extends Dream,
+  GMN,
+> = GMN extends keyof GlobalModelNameTableMap<I>
   ? GlobalModelNameTableMap<I>[GMN]
   : GMN extends (keyof GlobalModelNameTableMap<I>)[]
     ? GlobalModelNameTableMap<I>[GMN[number]]

--- a/test-app/app/models/Balloon.ts
+++ b/test-app/app/models/Balloon.ts
@@ -60,7 +60,7 @@ export default class Balloon extends ApplicationModel {
   @deco.HasMany('Sandbag', { foreignKey: 'balloonId' })
   public sandbags: Sandbag[]
 
-  @deco.BelongsTo(['Shape'], {
+  @deco.BelongsTo(() => [Shape], {
     foreignKey: 'shapableId',
     polymorphic: true,
     optional: true,

--- a/test-app/app/models/Balloon.ts
+++ b/test-app/app/models/Balloon.ts
@@ -60,7 +60,7 @@ export default class Balloon extends ApplicationModel {
   @deco.HasMany('Sandbag', { foreignKey: 'balloonId' })
   public sandbags: Sandbag[]
 
-  @deco.BelongsTo(() => [Shape], {
+  @deco.BelongsTo(['Shape'], {
     foreignKey: 'shapableId',
     polymorphic: true,
     optional: true,

--- a/test-app/app/models/Balloon/Latex.ts
+++ b/test-app/app/models/Balloon/Latex.ts
@@ -9,7 +9,7 @@ import Balloon from '../Balloon.js'
 // the wrong class name value.
 //
 // see https://github.com/evanw/esbuild/issues/1260 for more info
-@STI(Balloon)
+@STI(() => Balloon)
 export default class _Latex extends Balloon {
   public get serializers(): DreamSerializers<Balloon> {
     return {

--- a/test-app/app/models/Balloon/Latex/Animal.ts
+++ b/test-app/app/models/Balloon/Latex/Animal.ts
@@ -4,7 +4,7 @@ import { BalloonTypesEnum } from '../../../../types/db.js'
 import Balloon from '../../Balloon.js'
 import Latex from '../Latex.js'
 
-@STI(Balloon)
+@STI(() => Balloon)
 export default class Animal extends Latex {
   public override get type() {
     return (this as Animal).getAttribute('type')

--- a/test-app/app/models/Balloon/Mylar.ts
+++ b/test-app/app/models/Balloon/Mylar.ts
@@ -2,7 +2,7 @@ import STI from '../../../../src/decorators/class/STI.js'
 import { DreamSerializers } from '../../../../src/types/dream.js'
 import Balloon from '../Balloon.js'
 
-@STI(Balloon)
+@STI(() => Balloon)
 export default class Mylar extends Balloon {
   public get serializers(): DreamSerializers<Balloon> {
     return {

--- a/test-app/app/models/ExtraRating/HeartRating.ts
+++ b/test-app/app/models/ExtraRating/HeartRating.ts
@@ -1,5 +1,5 @@
 import STI from '../../../../src/decorators/class/STI.js'
 import BaseExtraRating from './Base.js'
 
-@STI(BaseExtraRating)
+@STI(() => BaseExtraRating)
 export default class HeartRating extends BaseExtraRating {}

--- a/test-app/app/models/ExtraRating/StarRating.ts
+++ b/test-app/app/models/ExtraRating/StarRating.ts
@@ -1,5 +1,5 @@
 import STI from '../../../../src/decorators/class/STI.js'
 import BaseExtraRating from './Base.js'
 
-@STI(BaseExtraRating)
+@STI(() => BaseExtraRating)
 export default class StarRating extends BaseExtraRating {}

--- a/test-app/app/models/Pet.ts
+++ b/test-app/app/models/Pet.ts
@@ -43,7 +43,7 @@ export default class Pet extends ApplicationModel {
   @deco.Sortable({ scope: 'species' })
   public positionWithinSpecies: number
 
-  @deco.BelongsTo('User', {
+  @deco.BelongsTo(() => User, {
     optional: true,
     primaryKeyOverride: 'uuid',
     foreignKey: 'userUuid',
@@ -51,7 +51,7 @@ export default class Pet extends ApplicationModel {
   public userThroughUuid: User | null
   public userUuid: string
 
-  @deco.BelongsTo('User', {
+  @deco.BelongsTo(() => User, {
     optional: true,
   })
   public user: User | null

--- a/test-app/app/models/Pet.ts
+++ b/test-app/app/models/Pet.ts
@@ -57,99 +57,99 @@ export default class Pet extends ApplicationModel {
   public user: User | null
   public userId: IdType
 
-  @deco.HasOne('Post', { through: 'user' })
+  @deco.HasOne(() => Post, { through: 'user' })
   public featuredPost: Post
 
-  @deco.HasMany('Rating', { through: 'user' })
+  @deco.HasMany(() => Rating, { through: 'user' })
   public ratings: Rating[]
 
-  @deco.HasMany('Rating', { through: 'user' })
+  @deco.HasMany(() => Rating, { through: 'user' })
   public featuredRatings: Rating[]
 
-  @deco.HasMany('Collar', { dependent: 'destroy' })
+  @deco.HasMany(() => Collar, { dependent: 'destroy' })
   public collars: Collar[]
 
-  @deco.HasOne('Collar', { and: { lost: false } })
+  @deco.HasOne(() => Collar, { and: { lost: false } })
   public currentCollar: Collar
 
   // begin: totally contrived for testing purposes
-  @deco.HasOne('Collar', { andNot: { lost: true } })
+  @deco.HasOne(() => Collar, { andNot: { lost: true } })
   public notLostCollar: Collar
 
-  @deco.HasMany('Collar', { distinct: 'tagName' })
+  @deco.HasMany(() => Collar, { distinct: 'tagName' })
   public uniqueCollars: Collar
 
-  @deco.HasMany('Balloon', { through: 'uniqueCollars', source: 'balloon' })
+  @deco.HasMany(() => Balloon, { through: 'uniqueCollars', source: 'balloon' })
   public uniqueBalloons: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', distinct: true })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', distinct: true })
   public distinctBalloons: Balloon
 
   // on
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: null } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: null } })
   public and_null: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.equal(null) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.equal(null) } })
   public and_opsEqual_null: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.not.equal(null) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.not.equal(null) } })
   public and_opsNotEqual_null: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: 'red' } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: 'red' } })
   public and_red: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.equal('red') } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.equal('red') } })
   public and_opsEqual_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     and: { color: ops.not.equal('red') },
   })
   public and_opsNotEqual_red: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ['red'] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ['red'] } })
   public and_redArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.in(['red']) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.in(['red']) } })
   public and_opsIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.not.in(['red']) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.not.in(['red']) } })
   public and_opsNotIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: [] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: [] } })
   public and_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.in([]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.in([]) } })
   public and_opsIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.not.in([]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.not.in([]) } })
   public and_opsNotIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: [null as any] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: [null as any] } })
   public and_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.in([null]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.in([null]) } })
   public and_opsIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', and: { color: ops.not.in([null]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', and: { color: ops.not.in([null]) } })
   public and_opsNotIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     and: { color: [null as any, 'red'] },
   })
   public and_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     and: { color: ops.in([null, 'red']) },
   })
   public and_opsIn_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     and: { color: ops.not.in([null, 'red']) },
@@ -158,89 +158,89 @@ export default class Pet extends ApplicationModel {
   // end: on
 
   // andNot
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: null } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: null } })
   public andNot_null: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.equal(null) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.equal(null) } })
   public andNot_opsEqual_null: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.not.equal(null) },
   })
   public andNot_opsNotEqual_null: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: 'red' } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: 'red' } })
   public andNot_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: 'red', type: 'Latex' },
   })
   public andNot_multipleClauses: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.equal('red') } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.equal('red') } })
   public andNot_opsEqual_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.not.equal('red') },
   })
   public andNot_opsNotEqual_red: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ['red'] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ['red'] } })
   public andNot_redArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.in(['red']) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.in(['red']) } })
   public andNot_opsIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.not.in(['red']) },
   })
   public andNot_opsNotIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: [] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: [] } })
   public andNot_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.in([]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.in([]) } })
   public andNot_opsIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.not.in([]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.not.in([]) } })
   public andNot_opsNotIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: [null as any] } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: [null as any] } })
   public andNot_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', { through: 'collars', source: 'balloon', andNot: { color: ops.in([null]) } })
+  @deco.HasMany(() => Balloon, { through: 'collars', source: 'balloon', andNot: { color: ops.in([null]) } })
   public andNot_opsIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.not.in([null]) },
   })
   public andNot_opsNotIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: [null as any, 'red'] },
   })
   public andNot_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.in([null, 'red']) },
   })
   public andNot_opsIn_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andNot: { color: ops.not.in([null, 'red']) },
@@ -250,126 +250,126 @@ export default class Pet extends ApplicationModel {
   // end: andNot
 
   // andAny
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: null }, { positionAlpha: null }],
   })
   public andAny_null: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.equal(null) }, { positionAlpha: null }],
   })
   public andAny_opsEqual_null: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.equal(null) }, { positionAlpha: null }],
   })
   public andAny_opsNotEqual_null: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: 'red' }, { positionAlpha: null }],
   })
   public andAny_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.equal('red') }, { positionAlpha: null }],
   })
   public andAny_opsEqual_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.equal('red') }, { positionAlpha: null }],
   })
   public andAny_opsNotEqual_red: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ['red'] }, { positionAlpha: null }],
   })
   public andAny_redArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.in(['red']) }, { positionAlpha: null }],
   })
   public andAny_opsIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.in(['red']) }, { positionAlpha: null }],
   })
   public andAny_opsNotIn_redArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: [] }, { positionAlpha: null }],
   })
   public andAny_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.in([]) }, { positionAlpha: null }],
   })
   public andAny_opsIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.in([]) }, { positionAlpha: null }],
   })
   public andAny_opsNotIn_emptyArray: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: [null as any] }, { positionAlpha: null }],
   })
   public andAny_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.in([null]) }, { positionAlpha: null }],
   })
   public andAny_opsIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.in([null]) }, { positionAlpha: null }],
   })
   public andAny_opsNotIn_arrayWithNull: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: [null as any, 'red'] }, { positionAlpha: null }],
   })
   public andAny_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.in([null, 'red']) }, { positionAlpha: null }],
   })
   public andAny_opsIn_arrayWithNullAndRed: Balloon
 
-  @deco.HasMany('Balloon', {
+  @deco.HasMany(() => Balloon, {
     through: 'collars',
     source: 'balloon',
     andAny: [{ color: ops.not.in([null, 'red']) }, { positionAlpha: null }],
@@ -377,10 +377,10 @@ export default class Pet extends ApplicationModel {
   public andAny_opsNotIn_arrayWithNullAndRed: Balloon
   // end: andAny
 
-  @deco.HasMany('PetUnderstudyJoinModel', { foreignKey: 'petId' })
+  @deco.HasMany(() => PetUnderstudyJoinModel, { foreignKey: 'petId' })
   public petUnderstudies: PetUnderstudyJoinModel[]
 
-  @deco.HasMany('Pet', {
+  @deco.HasMany(() => Pet, {
     through: 'petUnderstudies',
     source: 'understudy',
     distinct: true,

--- a/test-app/app/models/PetUnderstudyJoinModel.ts
+++ b/test-app/app/models/PetUnderstudyJoinModel.ts
@@ -18,7 +18,7 @@ export default class PetUnderstudyJoinModel extends ApplicationModel {
   public createdAt: DreamColumn<PetUnderstudyJoinModel, 'createdAt'>
   public updatedAt: DreamColumn<PetUnderstudyJoinModel, 'updatedAt'>
 
-  @deco.BelongsTo('Pet')
+  @deco.BelongsTo(() => Pet)
   public pet: Pet
   public petId: DreamColumn<PetUnderstudyJoinModel, 'petId'>
 

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -63,7 +63,7 @@ export default class Post extends ApplicationModel {
   // by passing withoutDefaultScopes, we
   // override the default scope, allowing us
   // to see null bodies
-  @deco.HasMany(() => NonNullRating, {
+  @deco.HasMany('NonNullRating', {
     foreignKey: 'rateableId',
     polymorphic: true,
     dependent: 'destroy',

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -38,7 +38,7 @@ export default class Post extends ApplicationModel {
   public postVisibility: PostVisibility | null
   public postVisibilityId: DreamColumn<Post, 'postVisibilityId'>
 
-  @deco.HasMany(() => PostComment, { dependent: 'destroy' })
+  @deco.HasMany('PostComment', { dependent: 'destroy' })
   public comments: PostComment[]
 
   @deco.HasMany('PostComment', { withoutDefaultScopes: ['dream:SoftDelete'] })

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -34,27 +34,27 @@ export default class Post extends ApplicationModel {
   public user: User
   public userId: DreamColumn<Post, 'userId'>
 
-  @deco.BelongsTo('PostVisibility', { optional: true })
+  @deco.BelongsTo(() => PostVisibility, { optional: true })
   public postVisibility: PostVisibility | null
   public postVisibilityId: DreamColumn<Post, 'postVisibilityId'>
 
-  @deco.HasMany('PostComment', { dependent: 'destroy' })
+  @deco.HasMany(() => PostComment, { dependent: 'destroy' })
   public comments: PostComment[]
 
-  @deco.HasMany('PostComment', { withoutDefaultScopes: ['dream:SoftDelete'] })
+  @deco.HasMany(() => PostComment, { withoutDefaultScopes: ['dream:SoftDelete'] })
   public allComments: PostComment[]
 
-  @deco.HasMany('Rating', {
+  @deco.HasMany(() => Rating, {
     foreignKey: 'rateableId',
     polymorphic: true,
     dependent: 'destroy',
   })
   public ratings: Rating[]
 
-  @deco.HasMany('PostComment', { and: { body: undefined as unknown as string } })
+  @deco.HasMany(() => PostComment, { and: { body: undefined as unknown as string } })
   public invalidWherePostComments: PostComment[]
 
-  @deco.HasMany('PostComment', { andNot: { body: undefined as unknown as string } })
+  @deco.HasMany(() => PostComment, { andNot: { body: undefined as unknown as string } })
   public invalidWhereNotPostComments: PostComment[]
 
   // Traveling through NonNullRating, a model
@@ -63,7 +63,7 @@ export default class Post extends ApplicationModel {
   // by passing withoutDefaultScopes, we
   // override the default scope, allowing us
   // to see null bodies
-  @deco.HasMany('NonNullRating', {
+  @deco.HasMany(() => NonNullRating, {
     foreignKey: 'rateableId',
     polymorphic: true,
     dependent: 'destroy',
@@ -71,7 +71,7 @@ export default class Post extends ApplicationModel {
   })
   public overriddenNonNullRatings: NonNullRating[]
 
-  @deco.HasMany('ExtraRating/HeartRating', {
+  @deco.HasMany(() => HeartRating, {
     foreignKey: 'extraRateableId',
     polymorphic: true,
     dependent: 'destroy',

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -30,7 +30,7 @@ export default class Post extends ApplicationModel {
 
   public body: DreamColumn<Post, 'body'>
 
-  @deco.BelongsTo('User')
+  @deco.BelongsTo(() => User)
   public user: User
   public userId: DreamColumn<Post, 'userId'>
 

--- a/test-app/app/models/Post.ts
+++ b/test-app/app/models/Post.ts
@@ -38,7 +38,7 @@ export default class Post extends ApplicationModel {
   public postVisibility: PostVisibility | null
   public postVisibilityId: DreamColumn<Post, 'postVisibilityId'>
 
-  @deco.HasMany('PostComment', { dependent: 'destroy' })
+  @deco.HasMany(() => PostComment, { dependent: 'destroy' })
   public comments: PostComment[]
 
   @deco.HasMany('PostComment', { withoutDefaultScopes: ['dream:SoftDelete'] })

--- a/test-app/app/models/PostComment.ts
+++ b/test-app/app/models/PostComment.ts
@@ -18,10 +18,10 @@ export default class PostComment extends ApplicationModel {
   public createdAt: DreamColumn<PostComment, 'createdAt'>
   public updatedAt: DreamColumn<PostComment, 'updatedAt'>
 
-  @deco.BelongsTo('Post')
+  @deco.BelongsTo(() => Post)
   public post: Post
   public postId: DreamColumn<PostComment, 'postId'>
 
-  @deco.BelongsTo('Post', { foreignKey: 'postId', withoutDefaultScopes: ['dream:SoftDelete'] })
+  @deco.BelongsTo(() => Post, { foreignKey: 'postId', withoutDefaultScopes: ['dream:SoftDelete'] })
   public postEvenIfDeleted: Post
 }

--- a/test-app/app/models/PostVisibility.ts
+++ b/test-app/app/models/PostVisibility.ts
@@ -20,7 +20,7 @@ export default class PostVisibility extends ApplicationModel {
   public createdAt: DreamColumn<PostVisibility, 'createdAt'>
   public updatedAt: DreamColumn<PostVisibility, 'updatedAt'>
 
-  @deco.HasOne('Post', { dependent: 'destroy' })
+  @deco.HasOne(() => Post, { dependent: 'destroy' })
   public post: Post
 
   @deco.BeforeCreate()

--- a/test-app/app/models/Rating.ts
+++ b/test-app/app/models/Rating.ts
@@ -24,7 +24,7 @@ export default class Rating extends ApplicationModel {
   public user: User
   public userId: DreamColumn<Rating, 'userId'>
 
-  @deco.BelongsTo(() => [Composition, Post], {
+  @deco.BelongsTo(['Composition', 'Post'], {
     foreignKey: 'rateableId',
     polymorphic: true,
   })

--- a/test-app/app/models/Rating.ts
+++ b/test-app/app/models/Rating.ts
@@ -32,7 +32,7 @@ export default class Rating extends ApplicationModel {
   public rateableId: DreamColumn<Rating, 'rateableId'>
   public rateableType: DreamColumn<Rating, 'rateableType'>
 
-  @deco.BelongsTo(['Post', 'Composition'], {
+  @deco.BelongsTo(() => [Post, Composition], {
     foreignKey: 'rateableId',
     polymorphic: true,
     withoutDefaultScopes: ['dream:SoftDelete'],

--- a/test-app/app/models/Rating.ts
+++ b/test-app/app/models/Rating.ts
@@ -24,7 +24,7 @@ export default class Rating extends ApplicationModel {
   public user: User
   public userId: DreamColumn<Rating, 'userId'>
 
-  @deco.BelongsTo(['Composition', 'Post'], {
+  @deco.BelongsTo(() => [Composition, Post], {
     foreignKey: 'rateableId',
     polymorphic: true,
   })

--- a/test-app/app/models/Sandbag.ts
+++ b/test-app/app/models/Sandbag.ts
@@ -32,7 +32,7 @@ export default class Sandbag extends ApplicationModel {
       this.addError('weight', 'cannot include weightTons AND weight')
   }
 
-  @deco.BelongsTo('Balloon/Mylar', { foreignKey: 'balloonId' })
+  @deco.BelongsTo(() => Mylar, { foreignKey: 'balloonId' })
   public mylar: Mylar
   public balloonId: DreamColumn<Sandbag, 'balloonId'>
 

--- a/test-app/app/models/Shape/Cat.ts
+++ b/test-app/app/models/Shape/Cat.ts
@@ -1,5 +1,5 @@
 import STI from '../../../../src/decorators/class/STI.js'
 import Shape from '../Shape.js'
 
-@STI(Shape)
+@STI(() => Shape)
 export default class CatShape extends Shape {}

--- a/test-app/app/models/Shape/Regular.ts
+++ b/test-app/app/models/Shape/Regular.ts
@@ -1,5 +1,5 @@
 import STI from '../../../../src/decorators/class/STI.js'
 import Shape from '../Shape.js'
 
-@STI(Shape)
+@STI(() => Shape)
 export default class RegularShape extends Shape {}

--- a/test-app/app/models/User.ts
+++ b/test-app/app/models/User.ts
@@ -85,10 +85,10 @@ export default class User extends ApplicationModel {
   @deco.Validates('length', { min: 4, max: 64 })
   public email: DreamColumn<User, 'email'>
 
-  @deco.HasOne('UserSettings')
+  @deco.HasOne(() => UserSettings)
   public userSettings: UserSettings
 
-  @deco.HasMany('Post')
+  @deco.HasMany(() => Post)
   // @deco.HasMany('Post', { dependent: 'destroy' })
   public posts: Post[]
 
@@ -98,7 +98,7 @@ export default class User extends ApplicationModel {
   @deco.HasMany('Post', { order: 'position' })
   public orderedPosts: Post[]
 
-  @deco.HasMany('PostComment', { through: 'posts', source: 'comments' })
+  @deco.HasMany(() => PostComment, { through: 'posts', source: 'comments' })
   public postComments: PostComment[]
 
   @deco.HasMany('PostComment', {

--- a/test-app/app/models/User.ts
+++ b/test-app/app/models/User.ts
@@ -92,22 +92,22 @@ export default class User extends ApplicationModel {
   // @deco.HasMany('Post', { dependent: 'destroy' })
   public posts: Post[]
 
-  @deco.HasMany('Post', { withoutDefaultScopes: ['dream:SoftDelete'] })
+  @deco.HasMany(() => Post, { withoutDefaultScopes: ['dream:SoftDelete'] })
   public allPosts: Post[]
 
-  @deco.HasMany('Post', { order: 'position' })
+  @deco.HasMany(() => Post, { order: 'position' })
   public orderedPosts: Post[]
 
   @deco.HasMany(() => PostComment, { through: 'posts', source: 'comments' })
   public postComments: PostComment[]
 
-  @deco.HasMany('PostComment', {
+  @deco.HasMany(() => PostComment, {
     through: 'allPosts',
     source: 'allComments',
   })
   public allPostComments: PostComment[]
 
-  @deco.HasMany('Rating')
+  @deco.HasMany(() => Rating)
   public ratings: Rating[]
 
   @deco.HasMany('ExtraRating/HeartRating')

--- a/test-app/app/models/User.ts
+++ b/test-app/app/models/User.ts
@@ -110,57 +110,57 @@ export default class User extends ApplicationModel {
   @deco.HasMany(() => Rating)
   public ratings: Rating[]
 
-  @deco.HasMany('ExtraRating/HeartRating')
+  @deco.HasMany(() => HeartRating)
   public heartRatings: HeartRating[]
 
-  @deco.HasMany('Rating', { through: 'posts', source: 'ratings' })
+  @deco.HasMany(() => Rating, { through: 'posts', source: 'ratings' })
   public postRatings: Rating[]
 
-  @deco.HasOne('Post', { selfAnd: { position: 'featuredPostPosition' } })
+  @deco.HasOne(() => Post, { selfAnd: { position: 'featuredPostPosition' } })
   public featuredPost: Post
 
-  @deco.HasMany('Rating', { through: 'featuredPost', source: 'ratings' })
+  @deco.HasMany(() => Rating, { through: 'featuredPost', source: 'ratings' })
   public featuredRatings: Rating[]
 
-  @deco.HasMany('Rating', {
+  @deco.HasMany(() => Rating, {
     through: 'posts',
     source: 'ratings',
     selfAnd: { rating: 'targetRating' },
   })
   public ratingsThroughPostsThatMatchUserTargetRating: Rating[]
 
-  @deco.HasMany('Composition', { dependent: 'destroy' })
+  @deco.HasMany(() => Composition, { dependent: 'destroy' })
   public compositions: Composition[]
 
-  @deco.HasOne('Composition', {
+  @deco.HasOne(() => Composition, {
     and: { primary: true },
   })
   public mainComposition: Composition
 
-  @deco.HasMany('IncompatibleForeignKeyTypeExample')
+  @deco.HasMany(() => IncompatibleForeignKeyTypeExample)
   public incompatibleForeignKeyTypeExamples: IncompatibleForeignKeyTypeExample[]
 
-  @deco.HasMany('CompositionAsset', {
+  @deco.HasMany(() => CompositionAsset, {
     through: 'compositions',
   })
   public compositionAssets: CompositionAsset[]
 
-  @deco.HasOne('CompositionAsset', {
+  @deco.HasOne(() => CompositionAsset, {
     through: 'mainComposition',
   })
   public mainCompositionAsset: CompositionAsset
 
-  @deco.HasMany('Composition', {
+  @deco.HasMany(() => Composition, {
     order: { id: 'desc' },
   })
   public reverseOrderedCompositions: Composition[]
 
-  @deco.HasMany('Composition', {
+  @deco.HasMany(() => Composition, {
     order: { content: 'asc', id: 'desc' },
   })
   public sortedCompositions: Composition[]
 
-  @deco.HasMany('Composition', {
+  @deco.HasMany(() => Composition, {
     order: {
       content: 'asc',
       id: 'desc',
@@ -168,30 +168,30 @@ export default class User extends ApplicationModel {
   })
   public sortedCompositions2: Composition[]
 
-  @deco.HasMany('CompositionAssetAudit', {
+  @deco.HasMany(() => CompositionAssetAudit, {
     through: 'compositionAssets',
   })
   public compositionAssetAudits: CompositionAssetAudit[]
 
   // recent associations
-  @deco.HasMany('Composition', {
+  @deco.HasMany(() => Composition, {
     and: { createdAt: () => range(DateTime.now().minus({ week: 1 })) },
   })
   public recentCompositions: Composition[]
 
   // not recent associations (contrived so that we can test whereNot)
-  @deco.HasMany('Composition', {
+  @deco.HasMany(() => Composition, {
     andNot: { createdAt: () => range(DateTime.now().minus({ week: 1 })) },
   })
   public notRecentCompositions: Composition[]
 
-  @deco.HasMany('CompositionAsset', {
+  @deco.HasMany(() => CompositionAsset, {
     through: 'recentCompositions',
     source: 'compositionAssets',
   })
   public recentCompositionAssets: CompositionAsset[]
 
-  @deco.HasMany('CompositionAsset', {
+  @deco.HasMany(() => CompositionAsset, {
     through: 'recentCompositions',
     source: 'mainCompositionAsset',
   })
@@ -200,31 +200,31 @@ export default class User extends ApplicationModel {
   // end:recent associations
 
   // missing through association
-  @deco.HasMany('CompositionAsset', { through: 'nonExtantCompositions' as any })
+  @deco.HasMany(() => CompositionAsset, { through: 'nonExtantCompositions' as any })
   public nonExtantCompositionAssets1: CompositionAsset[]
   // end: missing through association
 
   // missing through association source
-  @deco.HasMany('CompositionAsset', { through: 'compositions' })
+  @deco.HasMany(() => CompositionAsset, { through: 'compositions' })
   public nonExtantCompositionAssets2: CompositionAsset[]
   // end: missing through association source
 
-  @deco.HasMany('Balloon')
+  @deco.HasMany(() => Balloon)
   public balloons: Balloon[]
 
-  @deco.HasMany('BalloonLine', { through: 'balloons', source: 'balloonLine' })
+  @deco.HasMany(() => BalloonLine, { through: 'balloons', source: 'balloonLine' })
   public balloonLines: BalloonLine[]
 
-  @deco.HasMany('Pet')
+  @deco.HasMany(() => Pet)
   public pets: Pet[]
 
   // allows us to find hidden pets
-  @deco.HasMany('Pet', {
+  @deco.HasMany(() => Pet, {
     withoutDefaultScopes: ['dream:SoftDelete'],
   })
   public allPets: Pet[]
 
-  @deco.HasMany('Pet', { foreignKey: 'userUuid', primaryKeyOverride: 'uuid' })
+  @deco.HasMany(() => Pet, { foreignKey: 'userUuid', primaryKeyOverride: 'uuid' })
   public petsFromUuid: Pet[]
 
   @deco.HasOne('Pet', { foreignKey: 'userUuid', primaryKeyOverride: 'uuid' })

--- a/test-app/app/models/UserSettings.ts
+++ b/test-app/app/models/UserSettings.ts
@@ -22,7 +22,7 @@ intentionally try to call .serializers on it.`)
   public createdAt: DreamColumn<UserSettings, 'createdAt'>
   public updatedAt: DreamColumn<UserSettings, 'updatedAt'>
 
-  @deco.BelongsTo('User')
+  @deco.BelongsTo(() => User)
   public user: User
   public userId: DreamColumn<UserSettings, 'userId'>
 }


### PR DESCRIPTION
Restoring support for this syntax, since now that serializers are no longer problematic with regards to circular dependencies, it is my hunch that, even in the most complex circumstances, our patterns should be safe from circular dependencies, provided we are at Node > 22

essentially, this means that while we will continue to support the global name syntax for models, you can also optionally revert to our original, circular-dependency-safe cb function api, like so:

```ts
@deco.HasMany(() => Post)
```

close https://rvohealth.atlassian.net/browse/PDTC-7940