### PR TITLE
A common use case for the preloadFor/loadFor callback function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "0.45.4",
+  "version": "0.46.0",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/leftJoinLoadFor.spec.ts
+++ b/spec/unit/dream/leftJoinLoadFor.spec.ts
@@ -29,7 +29,7 @@ describe('Dream#leftJoinLoadFor(serializerKey)', () => {
       const collar = await Collar.create({ pet })
 
       const reloaded = await collar
-        .leftJoinLoadFor('default', (dreamClass, associationName) => {
+        .leftJoinLoadFor('default', (associationName, dreamClass) => {
           if (dreamClass.typeof(Pet) && associationName === 'ratings') {
             const modifier: DreamClassAssociationAndStatement<typeof Post, 'ratings'> = {
               and: { rating: 7 },

--- a/spec/unit/dream/loadFor.spec.ts
+++ b/spec/unit/dream/loadFor.spec.ts
@@ -29,7 +29,7 @@ describe('Dream#loadFor(serializerKey)', () => {
       const collar = await Collar.create({ pet })
 
       const reloaded = await collar
-        .loadFor('default', (dreamClass, associationName) => {
+        .loadFor('default', (associationName, dreamClass) => {
           if (dreamClass.typeof(Pet) && associationName === 'ratings') {
             const modifier: DreamClassAssociationAndStatement<typeof Post, 'ratings'> = {
               and: { rating: 7 },

--- a/spec/unit/query/leftJoinPreloadFor.spec.ts
+++ b/spec/unit/query/leftJoinPreloadFor.spec.ts
@@ -29,7 +29,7 @@ describe('Dream.leftJoinPreloadFor(serializerKey)', () => {
       await Collar.create({ pet })
 
       const collar = await Collar.query()
-        .leftJoinPreloadFor('default', (dreamClass, associationName) => {
+        .leftJoinPreloadFor('default', (associationName, dreamClass) => {
           if (dreamClass.typeof(Pet) && associationName === 'ratings') {
             const modifier: DreamClassAssociationAndStatement<typeof Post, 'ratings'> = {
               and: { rating: 7 },

--- a/spec/unit/query/preloadFor.spec.ts
+++ b/spec/unit/query/preloadFor.spec.ts
@@ -29,7 +29,7 @@ describe('Dream.preloadFor(serializerKey)', () => {
       await Collar.create({ pet })
 
       const collar = await Collar.query()
-        .preloadFor('default', (dreamClass, associationName) => {
+        .preloadFor('default', (associationName, dreamClass) => {
           if (dreamClass.typeof(Pet) && associationName === 'ratings') {
             const modifier: DreamClassAssociationAndStatement<typeof Post, 'ratings'> = {
               and: { rating: 7 },

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -1464,14 +1464,14 @@ export default class Dream {
    * await User.preloadFor('summary').all()
    *
    * // Add where conditions to specific associations during preloading:
-   * await User.preloadFor('default', (dreamClass, associationName) => {
+   * await User.preloadFor('default', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
    * }).all()
    *
    * // Skip preloading specific associations to handle them manually:
-   * await User.preloadFor('summary', (dreamClass, associationName) => {
+   * await User.preloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }
@@ -1519,14 +1519,14 @@ export default class Dream {
    * await User.leftJoinPreloadFor('summary').all()
    *
    * // Add where conditions to specific associations during left join preloading:
-   * await User.leftJoinPreloadFor('detailed', (dreamClass, associationName) => {
+   * await User.leftJoinPreloadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
    * }).all()
    *
    * // Skip left join preloading specific associations to handle them manually:
-   * await User.leftJoinPreloadFor('summary', (dreamClass, associationName) => {
+   * await User.leftJoinPreloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }
@@ -3977,7 +3977,7 @@ export default class Dream {
    * await user.loadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.loadFor('detailed', (dreamClass, associationName) => {
+   * await user.loadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -3986,7 +3986,7 @@ export default class Dream {
    *
    * // Skip preloading specific associations to handle them manually:
    * await user
-   *   .loadFor('summary', (dreamClass, associationName) => {
+   *   .loadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }
@@ -4074,7 +4074,7 @@ export default class Dream {
    * await user.leftJoinLoadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.leftJoinLoadFor('detailed', (dreamClass, associationName) => {
+   * await user.leftJoinLoadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -4083,7 +4083,7 @@ export default class Dream {
    *
    * // Skip preloading specific associations to handle them manually:
    * await user
-   *   .loadFor('summary', (dreamClass, associationName) => {
+   *   .loadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }

--- a/src/dream/DreamClassTransactionBuilder.ts
+++ b/src/dream/DreamClassTransactionBuilder.ts
@@ -524,14 +524,14 @@ export default class DreamClassTransactionBuilder<
    * await User.preloadFor('summary').all()
    *
    * // Add where conditions to specific associations during preloading:
-   * await User.txn(txn).leftJoinPreloadFor('detailed', (dreamClass, associationName) => {
+   * await User.txn(txn).leftJoinPreloadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
    * }).all()
    *
    * // Skip preloading specific associations to handle them manually:
-   * await User.txn(txn).leftJoinPreloadFor('summary', (dreamClass, associationName) => {
+   * await User.txn(txn).leftJoinPreloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }
@@ -605,14 +605,14 @@ export default class DreamClassTransactionBuilder<
    * await User.preloadFor('summary').all()
    *
    * // Add where conditions to specific associations during preloading:
-   * await User.txn(txn).preloadFor('detailed', (dreamClass, associationName) => {
+   * await User.txn(txn).preloadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
    * }).all()
    *
    * // Skip preloading specific associations to handle them manually:
-   * await User.txn(txn).preloadFor('summary', (dreamClass, associationName) => {
+   * await User.txn(txn).preloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }

--- a/src/dream/DreamInstanceTransactionBuilder.ts
+++ b/src/dream/DreamInstanceTransactionBuilder.ts
@@ -120,7 +120,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
    * await user.loadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.txn(txn).loadFor('detailed', (dreamClass, associationName) => {
+   * await user.txn(txn).loadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -130,7 +130,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
    * // Skip preloading specific associations to handle them manually:
    * await user
    *   .txn(txn)
-   *   .loadFor('summary', (dreamClass, associationName) => {
+   *   .loadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }
@@ -223,7 +223,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
    * await user.leftJoinLoadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.txn(txn).leftJoinLoadFor('detailed', (dreamClass, associationName) => {
+   * await user.txn(txn).leftJoinLoadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -233,7 +233,7 @@ export default class DreamInstanceTransactionBuilder<DreamInstance extends Dream
    * // Skip preloading specific associations to handle them manually:
    * await user
    *   .txn(txn)
-   *   .leftJoinLoadFor('summary', (dreamClass, associationName) => {
+   *   .leftJoinLoadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }

--- a/src/dream/LeftJoinLoadBuilder.ts
+++ b/src/dream/LeftJoinLoadBuilder.ts
@@ -96,7 +96,7 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
    * await user.leftJoinLoadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.leftJoinLoadFor('detailed', (dreamClass, associationName) => {
+   * await user.leftJoinLoadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -105,7 +105,7 @@ export default class LeftJoinLoadBuilder<DreamInstance extends Dream> {
    *
    * // Skip preloading specific associations to handle them manually:
    * await user
-   *   .leftJoinLoadFor('summary', (dreamClass, associationName) => {
+   *   .leftJoinLoadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }

--- a/src/dream/LoadBuilder.ts
+++ b/src/dream/LoadBuilder.ts
@@ -88,7 +88,7 @@ export default class LoadBuilder<DreamInstance extends Dream> {
    * await user.loadFor('summary').execute()
    *
    * // Add where conditions to specific associations during preloading:
-   * await user.loadFor('detailed', (dreamClass, associationName) => {
+   * await user.loadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -97,7 +97,7 @@ export default class LoadBuilder<DreamInstance extends Dream> {
    *
    * // Skip preloading specific associations to handle them manually:
    * await user
-   *   .loadFor('summary', (dreamClass, associationName) => {
+   *   .loadFor('summary', (associationName, dreamClass) => {
    *     if (dreamClass.typeof(User) && associationName === 'posts') {
    *       return 'omit' // Handle posts preloading separately with custom logic
    *     }

--- a/src/dream/Query.ts
+++ b/src/dream/Query.ts
@@ -702,7 +702,7 @@ export default class Query<
    * await User.preloadFor('summary').all()
    *
    * // Add where conditions to specific associations during preloading:
-   * await User.preloadFor('detailed', (dreamClass, associationName) => {
+   * await User.preloadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -710,7 +710,7 @@ export default class Query<
    *   .all()
    *
    * // Skip preloading specific associations to handle them manually:
-   * await User.preloadFor('summary', (dreamClass, associationName) => {
+   * await User.preloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }
@@ -779,7 +779,7 @@ export default class Query<
    * await User.leftJoinPreloadFor('summary').all()
    *
    * // Add where conditions to specific associations during left join preloading:
-   * await User.leftJoinPreloadFor('detailed', (dreamClass, associationName) => {
+   * await User.leftJoinPreloadFor('detailed', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(Post) && associationName === 'comments') {
    *     return { and: { published: true } }
    *   }
@@ -787,7 +787,7 @@ export default class Query<
    *   .all()
    *
    * // Skip left join preloading specific associations to handle them manually:
-   * await User.leftJoinPreloadFor('summary', (dreamClass, associationName) => {
+   * await User.leftJoinPreloadFor('summary', (associationName, dreamClass) => {
    *   if (dreamClass.typeof(User) && associationName === 'posts') {
    *     return 'omit' // Handle posts preloading separately with custom logic
    *   }

--- a/src/dream/internal/convertDreamClassAndAssociationNameTupleArrayToPreloadArgs.ts
+++ b/src/dream/internal/convertDreamClassAndAssociationNameTupleArrayToPreloadArgs.ts
@@ -14,7 +14,7 @@ export default function convertDreamClassAndAssociationNameTupleArrayToPreloadAr
         ? `${dreamClassAndAssociationNameTuple[1]} as drsz${counter.count++}`
         : dreamClassAndAssociationNameTuple[1]
       if (!modifierFn) return aliasedAssociationName
-      const modifier = modifierFn(dreamClassAndAssociationNameTuple[0], associationName)
+      const modifier = modifierFn(associationName, dreamClassAndAssociationNameTuple[0])
       if (modifier === 'omit') return undefined
       return [aliasedAssociationName, modifier]
     })

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -205,6 +205,6 @@ export interface PaginatedDreamQueryResult<T extends Dream> {
 }
 
 export type LoadForModifierFn = (
-  dreamClass: typeof Dream,
-  associationName: string
+  associationName: string,
+  dreamClass: typeof Dream
 ) => { and?: object; andAny?: object; andNot?: object } | 'omit' | undefined


### PR DESCRIPTION
will be to compare solely against the association name (e.g. to omit all currentLocalizedText so that all localizedText can be loaded in a single query at the end), so we want the first argument to be the association name and the second argument to be the less commonly used Dream model so that the second argument can be omitted completely when not needed