### PR TITLE
enable CliFileWriter to accept fs.writeFile options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Add fs.writeFile options as third argument to CliFileWriter.write, enabling psychic to provide custom flags when writing openapi.json files.
+
 ## 1.1.0
 
 - Remove support for preloadThroughColumns. They were broken, fixing them would be overly complex, and the same effect can be obtained using flatten on a serializer rendersOne

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/src/cli/CliFileWriter.ts
+++ b/src/cli/CliFileWriter.ts
@@ -2,8 +2,12 @@ import * as fs from 'node:fs/promises'
 import DreamCLI from './index.js'
 
 export class CliFileWriter {
-  public static async write(filepath: string, contents: string) {
-    await cliFileWriter.write(filepath, contents)
+  public static async write(
+    filepath: string,
+    contents: string,
+    opts?: Parameters<(typeof fs)['writeFile']>[2]
+  ) {
+    await cliFileWriter.write(filepath, contents, opts)
   }
 
   public static async revert() {
@@ -16,14 +20,14 @@ export class CliFileWriter {
 
   private fileCache: Record<string, string> = {}
 
-  public async write(filepath: string, contents: string) {
+  public async write(filepath: string, contents: string, opts?: Parameters<(typeof fs)['writeFile']>[2]) {
     // if we have manually backed up this file, or else this file
     // has been written to twice in one CLI session, we want
     // to preserve the original backup, so we do not attempt
     // to cache a second time
     if (!this.fileCache[filepath]) await this.cache(filepath)
 
-    await fs.writeFile(filepath, contents)
+    await fs.writeFile(filepath, contents, opts)
   }
 
   public async revert() {


### PR DESCRIPTION
This will enable psychic to properly tap into this and leverage the `w+` flag for openapi files, which are written dynamically in specs.