### PR TITLE
CliFileWriter does not require an existing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+- CliFileWriter does not raise error if the file we are writing is not in the file system yet.
+
 ## 1.1.1
 
 - Add fs.writeFile options as third argument to CliFileWriter.write, enabling psychic to provide custom flags when writing openapi.json files.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/src/cli/CliFileWriter.ts
+++ b/src/cli/CliFileWriter.ts
@@ -39,8 +39,13 @@ export class CliFileWriter {
   }
 
   public async cache(filepath: string) {
-    const originalContents = (await fs.readFile(filepath)).toString()
-    this.fileCache[filepath] = originalContents
+    try {
+      const originalContents = (await fs.readFile(filepath)).toString()
+      this.fileCache[filepath] = originalContents
+    } catch {
+      // ignore error, since it is ok if this file
+      // doesn't exist; we only cache for existing files.
+    }
   }
 }
 


### PR DESCRIPTION
This is because we consider it valid to want to cache only if the file already exists. this behavior will enable psychic to properly leverage CliFileWriter when syncing openapi types