### PR TITLE
add lookup method to dream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Add Dream.import, enabling devs to tap into the IOC provided by dream to dodge circular import issues
+
 ## 1.1.2
 
 - CliFileWriter does not raise error if the file we are writing is not in the file system yet.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/lookup.spec.ts
+++ b/spec/unit/dream/lookup.spec.ts
@@ -1,0 +1,13 @@
+import ApplicationModel from '../../../test-app/app/models/ApplicationModel.js'
+import User from '../../../test-app/app/models/User.js'
+import BalloonSerializer from '../../../test-app/app/serializers/BalloonSerializer.js'
+
+describe('Dream.lookup', () => {
+  it('imports models', () => {
+    expect(ApplicationModel.lookup('User')).toEqual(User)
+  })
+
+  it('imports serilaizers', () => {
+    expect(ApplicationModel.lookup('BalloonSerializer')).toEqual(BalloonSerializer)
+  })
+})

--- a/src/Dream.ts
+++ b/src/Dream.ts
@@ -10,6 +10,7 @@ import { blankHooksFactory } from './decorators/field/lifecycle/shared.js'
 import resortAllRecords from './decorators/field/sortable/helpers/resortAllRecords.js'
 import { SortableFieldConfig } from './decorators/field/sortable/Sortable.js'
 import { ScopeStatement } from './decorators/static-method/Scope.js'
+import DreamApp from './dream-app/index.js'
 import DreamClassTransactionBuilder from './dream/DreamClassTransactionBuilder.js'
 import DreamInstanceTransactionBuilder from './dream/DreamInstanceTransactionBuilder.js'
 import DreamTransaction from './dream/DreamTransaction.js'
@@ -882,6 +883,27 @@ export default class Dream {
    */
   public static removeAllDefaultScopes<T extends typeof Dream>(this: T): Query<InstanceType<T>> {
     return this.query().removeAllDefaultScopes()
+  }
+
+  /**
+   * imports an object from the IOC. This is usually done in rare cases,
+   * in order to avoid circular dependencies, since you can always
+   * use regular imports to import models or serializers otherwise.
+   *
+   * @returns the found model or serializer, depending on what you are looking for
+   */
+  public static lookup<
+    T extends typeof Dream,
+    GlobalSchema = InstanceType<T>['globalSchema'],
+    GlobalNames = GlobalSchema['globalNames' & keyof GlobalSchema],
+    ModelGlobalNames = keyof GlobalNames['models' & keyof GlobalNames],
+    SerializerGlobalNames = (GlobalNames['serializers' & keyof GlobalNames] & unknown[])[number],
+    LookupName extends SerializerGlobalNames | ModelGlobalNames = SerializerGlobalNames | ModelGlobalNames,
+  >(this: T, lookupName: LookupName) {
+    const dreamApp = DreamApp.getOrFail()
+    const models = dreamApp.models
+    const serializers = dreamApp.serializers
+    return models[lookupName as keyof typeof models] || serializers[lookupName as keyof typeof serializers]
   }
 
   /**


### PR DESCRIPTION
enable devs to import models or serializers using the internal Dream IOC, enabling them to dodge circular import issues in rare edge cases.

close https://rvohealth.atlassian.net/browse/PDTC-8097