### PR TITLE
Cache Dream app earlier in the initialization sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- cache Dream app earlier in the initialization sequence
+
 ## 1.4.0
 
 - fix `preloadFor` infinite loop when serializers have circular references

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/src/dream-app/index.ts
+++ b/src/dream-app/index.ts
@@ -67,6 +67,12 @@ export default class DreamApp {
 
     await dreamApp.inflections?.()
 
+    if (!dreamApp.serializers) setCachedSerializers({})
+
+    cacheDreamApp(dreamApp)
+
+    if (!EnvInternal.boolean('BYPASS_DB_CONNECTIONS_DURING_INIT')) await this.setDatabaseTypeParsers()
+
     await deferCb?.(dreamApp)
 
     for (const plugin of dreamApp.plugins) {
@@ -76,12 +82,6 @@ export default class DreamApp {
     dreamApp.validateAppBuildIntegrity({
       bypassModelIntegrityCheck: opts.bypassModelIntegrityCheck || false,
     })
-
-    if (!dreamApp.serializers) setCachedSerializers({})
-
-    cacheDreamApp(dreamApp)
-
-    if (!EnvInternal.boolean('BYPASS_DB_CONNECTIONS_DURING_INIT')) await this.setDatabaseTypeParsers()
 
     return dreamApp
   }


### PR DESCRIPTION
Discovered issue when updating psychic-spec-helpers in which loading OpenAPI decorator on a controller attempted to load serializers, which requires
the Dream app to be loaded and cached.