### PR TITLE
Add `DreamMigrationHelpers.newTransaction()` to support explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+Add `DreamMigrationHelpers.newTransaction()` to support explicitly starting a new transaction within a migration.
+
 ## 1.5.0
 
 - add support for multiple database connections in a single dream application. To take advantage of this new feature, you can do the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,26 +4,69 @@
 
 In order to use dream, you must be using node = 18.15.0. A `.node-version` file exists at the root of this repo to flag the node version, but it will not work unless `nodenv` has been correctly installed on your machine.
 
+### Install postgres and mysql
+
+Homebrew example:
+
+```sh
+brew install postgresql
+# follow post-install instructions
+brew install mysql
+# follow post-install instructions
+```
+
 ### Add ENV files
 
 make sure to add the following files to the root of the project:
 
 ```
 # .env
-DREAM_CORE_DEVELOPMENT=1
-DB_USER=YOUR_PG_USERNAME
-DB_NAME=dream_core_dev
+DB_USER=<your username>
 DB_PORT=5432
+DB_NAME=dream_app_development
 DB_HOST=localhost
+REPLICA_DB_NAME=dream_app_development
+REPLICA_DB_HOST=localhost
+
+DB_PORT_2=5432
+DB_NAME_2=dream_core_development_alternate
+
+DB_USER_MYSQL=root
+DB_PORT_MYSQL=3306
+DB_NAME_MYSQL=dream_core_development_mysql
+DB_HOST_MYSQL=localhost
+DB_PASSWORD_MYSQL=
+PRIMARY_DB_HOST_MYSQL=127.0.0.1
+REPLICA_DB_HOST_MYSQL=127.0.0.1
+
+APP_ENCRYPTION_KEY='UHClfbB+TJDVCMXfQO/uXgZTAg/BlGJfi6YLi8T2720='
+LEGACY_APP_ENCRYPTION_KEY='UHClfbB+TJDVCMXfQO/uXgZTAg/BlGJfi6YLi8T2720='
+TZ=UTC
 ```
 
 ```
 # .env.test
-DREAM_CORE_DEVELOPMENT=1
-DB_USER=YOUR_PG_USERNAME
-DB_NAME=dream_core_test
+DB_USER=<your username>
 DB_PORT=5432
+DB_NAME=dream_app_test
 DB_HOST=localhost
+REPLICA_DB_NAME=dream_app_test
+REPLICA_DB_HOST=localhost
+
+DB_PORT_2=5432
+DB_NAME_2=dream_core_test_alternate
+
+DB_USER_MYSQL=root
+DB_PORT_MYSQL=3306
+DB_NAME_MYSQL=dream_core_test_mysql
+DB_HOST_MYSQL=localhost
+DB_PASSWORD_MYSQL=
+PRIMARY_DB_HOST_MYSQL=127.0.0.1
+REPLICA_DB_HOST_MYSQL=127.0.0.1
+
+APP_ENCRYPTION_KEY='UHClfbB+TJDVCMXfQO/uXgZTAg/BlGJfi6YLi8T2720='
+LEGACY_APP_ENCRYPTION_KEY='UHClfbB+TJDVCMXfQO/uXgZTAg/BlGJfi6YLi8T2720='
+TZ=UTC
 ```
 
 ### Build db and sync schema
@@ -32,8 +75,8 @@ DB_HOST=localhost
 yarn install
 NODE_ENV=development yarn dream db:create
 NODE_ENV=development yarn dream db:migrate
-NODE_ENV=test yarn dream db:create
-NODE_ENV=test yarn dream db:migrate
+yarn dream db:create
+yarn dream db:migrate
 ```
 
 ## Global CLI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/src/dream/QueryDriver/helpers/kysely/runMigration.ts
+++ b/src/dream/QueryDriver/helpers/kysely/runMigration.ts
@@ -110,7 +110,9 @@ async function findNextMigrationRequiringNewTransaction(
   for (const notYetRunMigration of notYetRunMigrations) {
     const upAndDownString =
       notYetRunMigration.migration.up.toString() + (notYetRunMigration.migration.down || '').toString()
-    const migrationRequiresNewTransaction = upAndDownString.includes('DreamMigrationHelpers.dropEnumValue')
+    const migrationRequiresNewTransaction =
+      upAndDownString.includes('DreamMigrationHelpers.dropEnumValue') ||
+      upAndDownString.includes('DreamMigrationHelpers.newTransaction')
     if (migrationRequiresNewTransaction) return notYetRunMigration
   }
 }

--- a/test-app/db/migrations/1682458327691-test-manual-new-transaction-1.ts
+++ b/test-app/db/migrations/1682458327691-test-manual-new-transaction-1.ts
@@ -1,0 +1,7 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TYPE species ADD VALUE IF NOT EXISTS 'migration_transaction_test';`.execute(db)
+}
+
+export async function down(): Promise<void> {}

--- a/test-app/db/migrations/1682458327691-test-manual-new-transaction-2.ts
+++ b/test-app/db/migrations/1682458327691-test-manual-new-transaction-2.ts
@@ -1,0 +1,16 @@
+import { Kysely, sql } from 'kysely'
+import { DreamMigrationHelpers } from '../../../src/index.js'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  DreamMigrationHelpers.newTransaction()
+
+  await db.schema
+    .alterTable('pets')
+    .addCheckConstraint(
+      'species_migration_transaction_test_constraint',
+      sql`species != 'migration_transaction_test'`
+    )
+    .execute()
+}
+
+export async function down(): Promise<void> {}

--- a/test-app/types/db.ts
+++ b/test-app/types/db.ts
@@ -221,11 +221,12 @@ export const ShapeTypesEnumValues = [
 ] as const
 
 
-export type Species = "cat" | "dog" | "frog";
+export type Species = "cat" | "dog" | "frog" | "migration_transaction_test";
 export const SpeciesValues = [
   "cat",
   "dog",
-  "frog"
+  "frog",
+  "migration_transaction_test"
 ] as const
 
 


### PR DESCRIPTION
starting a new transaction within a migration.