### PR TITLE
Serializer builder attribute option types allow `required: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.3
+
+- serializer builder attribute option types allow `required: false`; this will be used by Psychic to omit attributes from the required array in OpenaAPI
+
 ## 1.9.2
 
 - allow null for ops argument to a where clause on a datetime or date column

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/src/types/serializer.ts
+++ b/src/types/serializer.ts
@@ -72,6 +72,7 @@ export type AutomaticSerializerAttributeOptions<
   precision?: DreamAttributeDbTypes<DreamInstance>[AttributeName] extends DecimalOpenapiTypesIncludingDbTypes
     ? RoundingPrecision
     : never
+  required?: false
 }
 
 export type AutomaticSerializerAttributeOptionsForType = {
@@ -86,12 +87,14 @@ export type SerializerAttributeOptionsForVirtualColumn = {
   as?: string
   default?: any
   openapi?: OpenapiDescription | OpenapiSchemaBodyShorthand | OpenapiShorthandPrimitiveTypes
+  required?: false
 }
 
 export type NonAutomaticSerializerAttributeOptions = {
   as?: string
   default?: any
   openapi: OpenapiSchemaBodyShorthand | OpenapiShorthandPrimitiveTypes
+  required?: false
 }
 
 export type NonAutomaticSerializerAttributeOptionsWithPossibleDecimalRenderOption =


### PR DESCRIPTION
This will be used by Psychic to omit attributes from the required array in OpenaAPI