### PR TITLE
if `required: false`, leave the property undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.4
+
+- if `required: false`, leave the property undefined rather than rendering as `null`
+
 ## 1.9.3
 
 - serializer builder attribute option types allow `required: false`; this will be used by Psychic to omit attributes from the required array in OpenaAPI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/serializer/ObjectSerializer/attribute.spec.ts
+++ b/spec/unit/serializer/ObjectSerializer/attribute.spec.ts
@@ -80,6 +80,29 @@ describe('ObjectSerializer attributes', () => {
     })
   })
 
+  context('undefined attributes', () => {
+    it('are rendered as null', () => {
+      const MySerializer = (data: User) => ObjectSerializer(data).attribute('email', { openapi: 'string' })
+
+      const serializer = MySerializer({ email: undefined as unknown as string, password: '123' })
+
+      expect(serializer.render()).toEqual({
+        email: null,
+      })
+    })
+
+    context('when required: false', () => {
+      it('are rendered as undefined', () => {
+        const MySerializer = (data: User) =>
+          ObjectSerializer(data).attribute('email', { required: false, openapi: 'string' })
+
+        const serializer = MySerializer({ email: undefined as unknown as string, password: '123' })
+
+        expect(serializer.render()).toEqual({})
+      })
+    })
+  })
+
   context('with casing specified', () => {
     const MySerializer = (data: ModelForOpenapiTypeSpecs) =>
       ObjectSerializer(data).attribute('requiredNicknames', { openapi: 'string[]' })

--- a/spec/unit/serializer/ObjectSerializer/customAttribute.spec.ts
+++ b/spec/unit/serializer/ObjectSerializer/customAttribute.spec.ts
@@ -67,4 +67,33 @@ describe('ObjectSerializer customAttributes', () => {
       expect(serializer.render()).toBeNull()
     })
   })
+
+  context('undefined attributes', () => {
+    it('are rendered as null', () => {
+      const MySerializer = (user: User) =>
+        ObjectSerializer(user).customAttribute('email', () => user.email, {
+          openapi: 'string',
+        })
+
+      const serializer = MySerializer({ email: undefined as unknown as string, password: '123' })
+
+      expect(serializer.render()).toEqual({
+        email: null,
+      })
+    })
+
+    context('when required: false', () => {
+      it('are rendered as undefined', () => {
+        const MySerializer = (user: User) =>
+          ObjectSerializer(user).customAttribute('email', () => user.email, {
+            required: false,
+            openapi: 'string',
+          })
+
+        const serializer = MySerializer({ email: undefined as unknown as string, password: '123' })
+
+        expect(serializer.render()).toEqual({})
+      })
+    })
+  })
 })

--- a/spec/unit/serializer/ObjectSerializer/delegatedAttribute.spec.ts
+++ b/spec/unit/serializer/ObjectSerializer/delegatedAttribute.spec.ts
@@ -75,4 +75,32 @@ describe('ObjectSerializer delegated attributes', () => {
       })
     })
   })
+
+  context('undefined attributes', () => {
+    it('are rendered as null', () => {
+      const pet: Pet = { name: undefined as unknown as string }
+
+      const MySerializer = (data: Pet) =>
+        ObjectSerializer(data).delegatedAttribute('user', 'name', { openapi: 'string' })
+
+      const serializer = MySerializer(pet)
+
+      expect(serializer.render()).toEqual({
+        name: null,
+      })
+    })
+
+    context('when required: false', () => {
+      it('are rendered as undefined', () => {
+        const pet: Pet = { name: undefined as unknown as string }
+
+        const MySerializer = (data: Pet) =>
+          ObjectSerializer(data).delegatedAttribute('user', 'name', { required: false, openapi: 'string' })
+
+        const serializer = MySerializer(pet)
+
+        expect(serializer.render()).toEqual({})
+      })
+    })
+  })
 })

--- a/src/serializer/SerializerRenderer.ts
+++ b/src/serializer/SerializerRenderer.ts
@@ -69,6 +69,7 @@ export default class SerializerRenderer {
         case 'attribute': {
           const outputAttributeName = this.setCase(attribute.options?.as ?? attribute.name)
           const value = data[attribute.name] ?? attribute.options?.default
+          if (value === undefined && attribute.options?.required === false) return accumulator
           accumulator[outputAttributeName] = applyRenderingOptionsToAttribute(
             value,
             attribute.options,
@@ -89,6 +90,7 @@ export default class SerializerRenderer {
           const outputAttributeName = this.setCase(attribute.options?.as ?? attribute.name)
           const target = data[attribute.targetName]
           const value = target?.[attribute.name] ?? attribute.options?.default
+          if (value === undefined && attribute.options?.required === false) return accumulator
           accumulator[outputAttributeName] = applyRenderingOptionsToAttribute(
             value,
             attribute.options,
@@ -110,14 +112,17 @@ export default class SerializerRenderer {
           // customAttributes don't support rendering options since the custom function should handle all
           // manipulation of the value
 
+          const value = attribute.fn()
+          if (value === undefined && attribute.options?.required === false) return accumulator
+
           if (attribute.options.flatten) {
             return {
               ...accumulator,
-              ...applyRenderingOptionsToAttribute(attribute.fn(), {}, this.passthroughData, this.renderOpts),
+              ...applyRenderingOptionsToAttribute(value, {}, this.passthroughData, this.renderOpts),
             }
           } else {
             accumulator[outputAttributeName] = applyRenderingOptionsToAttribute(
-              attribute.fn(),
+              value,
               {},
               this.passthroughData,
               this.renderOpts


### PR DESCRIPTION
rather than rendering as `null`