### PR TITLE
Avoid exponential N+1 problem during deletion cascades

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -15,7 +15,9 @@ MYSQL_DB_PASSWORD=
 PRIMARY_MYSQL_DB_HOST=127.0.0.1
 
 DB_NO_SSL=1
-APP_ENCRYPTION_KEY="e5/mF0mGE7njqIQ7iaK2g9Dzk9/JWdErLkYPYlVVp8M="
+APP_ENCRYPTION_KEY='<paste the encryption key generated from `pnpm dream g:encryption-key`>'
+LEGACY_APP_ENCRYPTION_KEY='<paste the encryption key generated from `pnpm dream g:encryption-key`>'
+COLUMN_ENCRYPTION_KEY='<paste the encryption key generated from `pnpm dream g:encryption-key`>'
 WEB_SERVICE=1
 WORKER_SERVICE=0
 CORS_HOSTS='["http://localhost:3000"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+- generate the full load tree and use `.load(...).execute(...)` to avoid exponential N+1 problem during deletion cascades
+
 ## 2.5.8
 
 - fix tsdocs for `Query#update`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - generate the full load tree and use `.load(...).execute(...)` to avoid exponential N+1 problem during deletion cascades
 - types now allow `optional` option for DreamSerializer `delegatedAttribute` (used by Psychic to customize OpenAPI shape of automatically inferred fields to allow `null`)
+- fix `rendersOne`, `rendersMany`, and `delegatedAttribute` witihn a generic serializer so their types work without providing generic type arguments
 
 ## 2.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.6.0
 
 - generate the full load tree and use `.load(...).execute(...)` to avoid exponential N+1 problem during deletion cascades
+- types now allow `optional` option for DreamSerializer `delegatedAttribute` (used by Psychic to customize OpenAPI shape of automatically inferred fields to allow `null`)
 
 ## 2.5.8
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.5.8",
+  "version": "2.6.0",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/reallyDestroy.spec.ts
+++ b/spec/unit/dream/reallyDestroy.spec.ts
@@ -1,5 +1,4 @@
 import * as destroyDreamModule from '../../../src/dream/internal/destroyDream.js'
-import Query from '../../../src/dream/Query.js'
 import ApplicationModel from '../../../test-app/app/models/ApplicationModel.js'
 import Collar from '../../../test-app/app/models/Collar.js'
 import Pet from '../../../test-app/app/models/Pet.js'
@@ -157,13 +156,17 @@ describe('Dream#reallyDestroy', () => {
           const user = await User.create({ email: 'how@yadoin', password: 'howyadoin' })
           const post = await Post.create({ user })
 
-          const spy = vi.spyOn(Query.prototype, 'destroy')
+          const spy = vi.spyOn(destroyDreamModule, 'default')
 
           await ApplicationModel.transaction(async txn => {
             await post.txn(txn).reallyDestroy({ skipHooks: true })
           })
 
-          expect(spy).toHaveBeenCalledWith(expect.objectContaining({ skipHooks: true }))
+          expect(spy).toHaveBeenCalledWith(
+            post,
+            expect.anything(),
+            expect.objectContaining({ skipHooks: true })
+          )
         })
       })
     })

--- a/spec/unit/dream/scenarios/destroy-circular-references.spec.ts
+++ b/spec/unit/dream/scenarios/destroy-circular-references.spec.ts
@@ -1,0 +1,90 @@
+import CircularReferenceModel from '../../../../test-app/app/models/CircularReferenceModel.js'
+import CircularReferenceModelA from '../../../../test-app/app/models/CircularReference/ModelA.js'
+import CircularReferenceModelB from '../../../../test-app/app/models/CircularReference/ModelB.js'
+
+describe('Dream#destroy with circular/self-referential dependent: destroy', () => {
+  context('self-referential tree (CircularReferenceModel)', () => {
+    it('destroys a chain of depth 2', async () => {
+      const root = await CircularReferenceModel.create({})
+      await CircularReferenceModel.create({ parent: root })
+
+      await root.destroy()
+
+      expect(await CircularReferenceModel.count()).toEqual(0)
+    })
+
+    it('destroys a chain of depth 4', async () => {
+      const root = await CircularReferenceModel.create({})
+      const level1 = await CircularReferenceModel.create({ parent: root })
+      const level2 = await CircularReferenceModel.create({ parent: level1 })
+      await CircularReferenceModel.create({ parent: level2 })
+
+      await root.destroy()
+
+      expect(await CircularReferenceModel.count()).toEqual(0)
+    })
+
+    it('destroys a chain of depth 6 (beyond the preload depth of 4)', async () => {
+      const root = await CircularReferenceModel.create({})
+      const level1 = await CircularReferenceModel.create({ parent: root })
+      const level2 = await CircularReferenceModel.create({ parent: level1 })
+      const level3 = await CircularReferenceModel.create({ parent: level2 })
+      const level4 = await CircularReferenceModel.create({ parent: level3 })
+      await CircularReferenceModel.create({ parent: level4 })
+
+      await root.destroy()
+
+      expect(await CircularReferenceModel.count()).toEqual(0)
+    })
+
+    it('destroys a chain of depth 8 (well beyond the preload depth of 4)', async () => {
+      const root = await CircularReferenceModel.create({})
+      let current = root
+      for (let i = 0; i < 7; i++) {
+        current = await CircularReferenceModel.create({ parent: current })
+      }
+
+      expect(await CircularReferenceModel.count()).toEqual(8)
+      await root.destroy()
+      expect(await CircularReferenceModel.count()).toEqual(0)
+    })
+  })
+
+  context('mutually-referential cycle (ModelA ↔ ModelB)', () => {
+    it('destroys a ModelA → ModelB chain', async () => {
+      const modelA = await CircularReferenceModelA.create({})
+      await CircularReferenceModelB.create({ modelAParent: modelA })
+
+      await modelA.destroy()
+
+      expect(await CircularReferenceModelA.removeAllDefaultScopes().count()).toEqual(0)
+      expect(await CircularReferenceModelB.removeAllDefaultScopes().count()).toEqual(0)
+    })
+
+    it('destroys a ModelA → ModelB → ModelA → ModelB chain (depth 4)', async () => {
+      const a1 = await CircularReferenceModelA.create({})
+      const b1 = await CircularReferenceModelB.create({ modelAParent: a1 })
+      const a2 = await CircularReferenceModelA.create({ modelBParent: b1 })
+      await CircularReferenceModelB.create({ modelAParent: a2 })
+
+      await a1.destroy()
+
+      expect(await CircularReferenceModelA.removeAllDefaultScopes().count()).toEqual(0)
+      expect(await CircularReferenceModelB.removeAllDefaultScopes().count()).toEqual(0)
+    })
+
+    it('destroys an A → B → A → B → A → B chain (depth 6, beyond preload depth)', async () => {
+      const a1 = await CircularReferenceModelA.create({})
+      const b1 = await CircularReferenceModelB.create({ modelAParent: a1 })
+      const a2 = await CircularReferenceModelA.create({ modelBParent: b1 })
+      const b2 = await CircularReferenceModelB.create({ modelAParent: a2 })
+      const a3 = await CircularReferenceModelA.create({ modelBParent: b2 })
+      await CircularReferenceModelB.create({ modelAParent: a3 })
+
+      await a1.destroy()
+
+      expect(await CircularReferenceModelA.removeAllDefaultScopes().count()).toEqual(0)
+      expect(await CircularReferenceModelB.removeAllDefaultScopes().count()).toEqual(0)
+    })
+  })
+})

--- a/spec/unit/load-builder/connection.spec.ts
+++ b/spec/unit/load-builder/connection.spec.ts
@@ -1,0 +1,28 @@
+import DreamDbConnection from '../../../src/db/DreamDbConnection.js'
+import Composition from '../../../test-app/app/models/Composition.js'
+import User from '../../../test-app/app/models/User.js'
+
+describe('LoadBuilder#connection', () => {
+  it('uses the specified connection when loading associations', async () => {
+    const user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+    await Composition.create({ user })
+
+    const spy = vi.spyOn(DreamDbConnection, 'getConnection')
+
+    await user.load('compositions').connection('replica').execute()
+
+    expect(spy).toHaveBeenCalledWith('default', 'replica', expect.anything())
+  })
+
+  it('defaults to primary connection', async () => {
+    const user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+    await Composition.create({ user })
+
+    const spy = vi.spyOn(DreamDbConnection, 'getConnection')
+
+    await user.load('compositions').execute()
+
+    expect(spy).toHaveBeenCalledWith('default', 'primary', expect.anything())
+    expect(spy).not.toHaveBeenCalledWith('default', 'replica', expect.anything())
+  })
+})

--- a/spec/unit/load-builder/removeAllDefaultScopes.spec.ts
+++ b/spec/unit/load-builder/removeAllDefaultScopes.spec.ts
@@ -1,0 +1,24 @@
+import Collar from '../../../test-app/app/models/Collar.js'
+import Pet from '../../../test-app/app/models/Pet.js'
+import User from '../../../test-app/app/models/User.js'
+
+describe('LoadBuilder#removeAllDefaultScopes', () => {
+  let user: User
+  let pet: Pet
+
+  beforeEach(async () => {
+    user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+    pet = await Pet.create({ user, name: 'aster' })
+  })
+
+  it('bypasses all default scopes when loading associations', async () => {
+    const hiddenCollar = await Collar.create({ pet, hidden: true })
+    await hiddenCollar.destroy()
+
+    const loaded = await pet.load('collars').execute()
+    expect(loaded.collars).toHaveLength(0)
+
+    const loadedWithBypass = await pet.load('collars').removeAllDefaultScopes().execute()
+    expect(loadedWithBypass.collars).toMatchDreamModels([hiddenCollar])
+  })
+})

--- a/spec/unit/load-builder/removeDefaultScope.spec.ts
+++ b/spec/unit/load-builder/removeDefaultScope.spec.ts
@@ -1,0 +1,46 @@
+import Collar from '../../../test-app/app/models/Collar.js'
+import Pet from '../../../test-app/app/models/Pet.js'
+import User from '../../../test-app/app/models/User.js'
+
+describe('LoadBuilder#removeDefaultScope', () => {
+  let user: User
+  let pet: Pet
+
+  beforeEach(async () => {
+    user = await User.create({ email: 'fred@frewd', password: 'howyadoin' })
+    pet = await Pet.create({ user, name: 'aster' })
+  })
+
+  it('bypasses the specified default scope when loading associations', async () => {
+    const hiddenCollar = await Collar.create({ pet, hidden: true })
+
+    const loaded = await pet.load('collars').execute()
+    expect(loaded.collars).toHaveLength(0)
+
+    const loadedWithBypass = await pet.load('collars').removeDefaultScope('hideHiddenCollars').execute()
+    expect(loadedWithBypass.collars).toMatchDreamModels([hiddenCollar])
+  })
+
+  it('bypasses the SoftDelete scope when loading associations', async () => {
+    const collar = await Collar.create({ pet, hidden: false })
+    await collar.destroy()
+
+    const loaded = await pet.load('collars').execute()
+    expect(loaded.collars).toHaveLength(0)
+
+    const loadedWithBypass = await pet.load('collars').removeDefaultScope('dream:SoftDelete').execute()
+    expect(loadedWithBypass.collars).toMatchDreamModels([collar])
+  })
+
+  it('can bypass multiple default scopes', async () => {
+    const hiddenCollar = await Collar.create({ pet, hidden: true })
+    await hiddenCollar.destroy()
+
+    const loadedWithBypass = await pet
+      .load('collars')
+      .removeDefaultScope('hideHiddenCollars')
+      .removeDefaultScope('dream:SoftDelete')
+      .execute()
+    expect(loadedWithBypass.collars).toMatchDreamModels([hiddenCollar])
+  })
+})

--- a/spec/unit/serializer/DreamSerializer/delegatedAttribute.spec.ts
+++ b/spec/unit/serializer/DreamSerializer/delegatedAttribute.spec.ts
@@ -11,7 +11,9 @@ describe('DreamSerializer#delegatedAttribute', () => {
 
     const MySerializer = (data: Pet) =>
       DreamSerializer(Pet, data)
-        .delegatedAttribute('user', 'name')
+        // `optional: true` only affects OpenAPI generation (in Psychic), but including here
+        // to ensure it is supported by types
+        .delegatedAttribute('user', 'name', { optional: true })
         // passing a generic argument here just to ensure the types stay correct
         .delegatedAttribute<Pet>('user', 'birthdate')
 

--- a/spec/unit/serializer/DreamSerializer/rendersMany.spec.ts
+++ b/spec/unit/serializer/DreamSerializer/rendersMany.spec.ts
@@ -197,6 +197,43 @@ describe('DreamSerializer#rendersMany', () => {
     })
   })
 
+  context('with casing specified', () => {
+    context('snake casing', () => {
+      it('applies snake casing to nested serializer keys', () => {
+        const birthdate = CalendarDate.fromISO('1950-10-02')
+        const user = User.new({ id: '7', name: 'Charlie', birthdate })
+        const pet1 = Pet.new({ id: '3', user, name: 'Snoopy', species: 'dog' })
+        const pet2 = Pet.new({ id: '4', user, name: 'Woodstock', species: 'frog' })
+        pet1.ratings = []
+        pet2.ratings = []
+        user.pets = [pet1, pet2]
+
+        const MySerializer = (data: User) => DreamSerializer(User, data).rendersMany('pets')
+
+        const serializer = MySerializer(user)
+
+        expect(serializer.render({}, { casing: 'snake' })).toEqual({
+          pets: [
+            {
+              id: pet1.id,
+              name: 'Snoopy',
+              favorite_days_of_week: ['Monday', 'Tuesday'],
+              species: 'dog',
+              ratings: [],
+            },
+            {
+              id: pet2.id,
+              name: 'Woodstock',
+              favorite_days_of_week: ['Monday', 'Tuesday'],
+              species: 'frog',
+              ratings: [],
+            },
+          ],
+        })
+      })
+    })
+  })
+
   // type tests are all intentionally skipped. Instead, add @ts-expect-error
   // comments, which will become invalid if the type errors stop raising
   context('type tests', () => {

--- a/spec/unit/serializer/DreamSerializer/rendersOne.spec.ts
+++ b/spec/unit/serializer/DreamSerializer/rendersOne.spec.ts
@@ -323,6 +323,29 @@ describe('DreamSerializer#rendersOne', () => {
     })
   })
 
+  context('with casing specified', () => {
+    context('snake casing', () => {
+      it('applies snake casing to nested serializer keys', () => {
+        const birthdate = CalendarDate.fromISO('1950-10-02')
+        const user = User.new({ id: '7', name: 'Charlie', birthdate })
+        const pet = Pet.new({ id: '3', user, name: 'Snoopy', species: 'dog' })
+
+        const MySerializer = (data: Pet) => DreamSerializer(Pet, data).rendersOne('user')
+
+        const serializer = MySerializer(pet)
+
+        expect(serializer.render({}, { casing: 'snake' })).toEqual({
+          user: {
+            id: user.id,
+            name: 'Charlie',
+            favorite_word: null,
+            birthdate: birthdate.toISO(),
+          },
+        })
+      })
+    })
+  })
+
   // type tests are all intentionally skipped. Instead, add @ts-expect-error
   // comments, which will become invalid if the type errors stop raising
   context('type tests', () => {

--- a/spec/unit/serializer/ObjectSerializer/rendersMany.spec.ts
+++ b/spec/unit/serializer/ObjectSerializer/rendersMany.spec.ts
@@ -160,6 +160,43 @@ describe('ObjectSerializer#rendersMany', () => {
       })
     })
 
+    context('with casing specified', () => {
+      context('snake casing', () => {
+        it('applies snake casing to nested serializer keys', () => {
+          const birthdate = CalendarDate.fromISO('1950-10-02')
+          const pet1: DreamPet = DreamPet.new({ id: '3', name: 'Snoopy', species: 'dog' })
+          const pet2: DreamPet = DreamPet.new({ id: '7', name: 'Woodstock', species: 'frog' })
+          pet1.ratings = []
+          pet2.ratings = []
+          const user: UserWithDreamPets = { id: '11', name: 'Charlie', birthdate, pets: [pet1, pet2] }
+
+          const MySerializer = (data: UserWithDreamPets) =>
+            ObjectSerializer(data).rendersMany('pets', { dreamClass: DreamPet })
+
+          const serializer = MySerializer(user)
+
+          expect(serializer.render({}, { casing: 'snake' })).toEqual({
+            pets: [
+              {
+                id: pet1.id,
+                name: 'Snoopy',
+                favorite_days_of_week: ['Monday', 'Tuesday'],
+                species: 'dog',
+                ratings: [],
+              },
+              {
+                id: pet2.id,
+                name: 'Woodstock',
+                favorite_days_of_week: ['Monday', 'Tuesday'],
+                species: 'frog',
+                ratings: [],
+              },
+            ],
+          })
+        })
+      })
+    })
+
     it('supports supplying a custom DreamSerializer', () => {
       const birthdate = CalendarDate.fromISO('1950-10-02')
       const pet1: SimplePet = { id: '3', name: 'Snoopy', species: 'dog' }

--- a/spec/unit/serializer/ObjectSerializer/rendersOne.spec.ts
+++ b/spec/unit/serializer/ObjectSerializer/rendersOne.spec.ts
@@ -146,6 +146,30 @@ describe('ObjectSerializer#rendersOne', () => {
       })
     })
 
+    context('with casing specified', () => {
+      context('snake casing', () => {
+        it('applies snake casing to nested serializer keys', () => {
+          const birthdate = CalendarDate.fromISO('1950-10-02')
+          const user = DreamUser.new({ id: '7', name: 'Charlie', birthdate })
+          const pet: PetWithDreamUser = { id: '3', user, name: 'Snoopy', species: 'dog' }
+
+          const MySerializer = (data: PetWithDreamUser) =>
+            ObjectSerializer(data).rendersOne('user', { dreamClass: DreamUser })
+
+          const serializer = MySerializer(pet)
+
+          expect(serializer.render({}, { casing: 'snake' })).toEqual({
+            user: {
+              id: user.id,
+              name: 'Charlie',
+              favorite_word: null,
+              birthdate: birthdate.toISO(),
+            },
+          })
+        })
+      })
+    })
+
     context('flatten', () => {
       it('renders the serialized data into this model and adjusts the OpenAPI spec accordingly', () => {
         const birthdate = CalendarDate.fromISO('1950-10-02')

--- a/src/dream/LoadBuilder.ts
+++ b/src/dream/LoadBuilder.ts
@@ -1,6 +1,7 @@
 import Dream from '../Dream.js'
 import { PassthroughOnClause } from '../types/associations/shared.js'
-import { DreamSerializerKey, PassthroughColumnNames } from '../types/dream.js'
+import { DbConnectionType } from '../types/db.js'
+import { AllDefaultScopeNames, DreamSerializerKey, PassthroughColumnNames } from '../types/dream.js'
 import { LoadForModifierFn, QueryWithJoinedAssociationsTypeAndNoLeftJoinPreload } from '../types/query.js'
 import { VariadicLoadArgs } from '../types/variadic.js'
 import DreamTransaction from './DreamTransaction.js'
@@ -37,6 +38,67 @@ export default class LoadBuilder<DreamInstance extends Dream> {
     PassthroughColumns extends PassthroughColumnNames<DreamInstance>,
   >(this: I, passthroughWhereStatement: PassthroughOnClause<PassthroughColumns>) {
     this.query = this.query.passthrough(passthroughWhereStatement)
+    return this
+  }
+
+  /**
+   * Prevents a specific default scope from applying when
+   * loading associations
+   *
+   * ```ts
+   * const user = await User.firstOrFail()
+   * const loaded = await user
+   *   .load('posts')
+   *   .removeDefaultScope('dream:SoftDelete')
+   *   .execute()
+   * ```
+   *
+   * @param scopeName - The default scope to bypass
+   * @returns The LoadBuilder instance for chaining
+   */
+  public removeDefaultScope<I extends LoadBuilder<DreamInstance>>(
+    this: I,
+    scopeName: AllDefaultScopeNames<DreamInstance>
+  ) {
+    this.query = this.query.removeDefaultScope(scopeName) as typeof this.query
+    return this
+  }
+
+  /**
+   * Prevents all default scopes from applying when
+   * loading associations
+   *
+   * ```ts
+   * const user = await User.firstOrFail()
+   * const loaded = await user
+   *   .load('posts')
+   *   .removeAllDefaultScopes()
+   *   .execute()
+   * ```
+   *
+   * @returns The LoadBuilder instance for chaining
+   */
+  public removeAllDefaultScopes<I extends LoadBuilder<DreamInstance>>(this: I) {
+    this.query = this.query.removeAllDefaultScopes() as typeof this.query
+    return this
+  }
+
+  /**
+   * Sets the database connection to use when loading associations
+   *
+   * ```ts
+   * const user = await User.firstOrFail()
+   * const loaded = await user
+   *   .load('posts')
+   *   .connection('replica')
+   *   .execute()
+   * ```
+   *
+   * @param connection - The connection type ('primary' or 'replica')
+   * @returns The LoadBuilder instance for chaining
+   */
+  public connection<I extends LoadBuilder<DreamInstance>>(this: I, connection: DbConnectionType) {
+    this.query = this.query.connection(connection)
     return this
   }
 

--- a/src/dream/internal/buildDependentDestroyPreloadPaths.ts
+++ b/src/dream/internal/buildDependentDestroyPreloadPaths.ts
@@ -1,0 +1,78 @@
+import Dream from '../../Dream.js'
+import { HasStatement } from '../../types/associations/shared.js'
+import { DreamClassAndAssociationNameTuple } from './extractNestedPaths.js'
+
+const MAX_REPEATS = 4
+const dependentDestroyPreloadPathsCache = new Map<string, DreamClassAndAssociationNameTuple[][]>()
+
+/**
+ * @internal
+ *
+ * Recursively walks `dependent: 'destroy'` associations starting from the given
+ * Dream class, producing an array of preload paths. Each path is an array of
+ * [DreamClass, associationName] tuples representing a chain from root to leaf.
+ *
+ * Allows the same Dream class to appear up to MAX_REPEATS times in a single
+ * path to support tree structures (e.g. a Category with `dependent: 'destroy'`
+ * on its children, which are also Categories).
+ *
+ * Used to build a preload tree so that all records in the cascade can be loaded
+ * upfront, eliminating N+1 queries during destroy.
+ */
+export default function buildDependentDestroyPreloadPaths(
+  dreamClass: typeof Dream
+): DreamClassAndAssociationNameTuple[][] {
+  const cacheKey = dreamClass.sanitizedName
+  const cached = dependentDestroyPreloadPathsCache.get(cacheKey)
+  if (cached) return cached
+
+  const paths: DreamClassAndAssociationNameTuple[][] = []
+  traverse(dreamClass, [], {}, paths)
+  dependentDestroyPreloadPathsCache.set(cacheKey, paths)
+  return paths
+}
+
+function traverse(
+  dreamClass: typeof Dream,
+  currentPath: DreamClassAndAssociationNameTuple[],
+  depthTracker: Record<string, number>,
+  paths: DreamClassAndAssociationNameTuple[][]
+) {
+  const trackerId = dreamClass.sanitizedName
+  depthTracker[trackerId] ??= 0
+  if (depthTracker[trackerId] + 1 > MAX_REPEATS) {
+    if (currentPath.length > 0) {
+      paths.push([...currentPath])
+    }
+    return
+  }
+  depthTracker[trackerId]++
+
+  const associationMap = dreamClass['associationMetadataMap']()
+  const dependentDestroyNames = Object.keys(associationMap).filter(
+    key => (associationMap[key] as HasStatement<any, any, any, any, any>).dependent === 'destroy'
+  )
+
+  if (dependentDestroyNames.length === 0) {
+    if (currentPath.length > 0) {
+      paths.push([...currentPath])
+    }
+    depthTracker[trackerId]--
+    return
+  }
+
+  for (const associationName of dependentDestroyNames) {
+    const association = associationMap[associationName]!
+    const modelCBResult = association.modelCB()
+    const targetClasses = Array.isArray(modelCBResult) ? modelCBResult : [modelCBResult]
+
+    for (const targetClass of targetClasses) {
+      const tuple: DreamClassAndAssociationNameTuple = [dreamClass, associationName]
+      const newPath = [...currentPath, tuple]
+
+      traverse(targetClass, newPath, { ...depthTracker }, paths)
+    }
+  }
+
+  depthTracker[trackerId]--
+}

--- a/src/dream/internal/destroyAssociatedRecords.ts
+++ b/src/dream/internal/destroyAssociatedRecords.ts
@@ -6,7 +6,11 @@ import { ReallyDestroyOptions } from './destroyDream.js'
  * @internal
  *
  * Destroys all HasOne/HasMany associations on this
- * dream that are marked as `dependent: 'destroy'`
+ * dream that are marked as `dependent: 'destroy'`.
+ *
+ * Expects associations to be preloaded onto the dream instance
+ * via `loadDependentDestroyTree`. Iterates loaded associations
+ * directly instead of querying the database.
  */
 export default async function destroyAssociatedRecords<I extends Dream>(
   dream: I,
@@ -14,14 +18,18 @@ export default async function destroyAssociatedRecords<I extends Dream>(
   options: ReallyDestroyOptions<I>
 ) {
   const dreamClass = dream.constructor as typeof Dream
-
   const { reallyDestroy } = options
 
   for (const associationName of dreamClass['dependentDestroyAssociationNames']()) {
-    if (reallyDestroy) {
-      await dream.txn(txn).reallyDestroyAssociation(associationName as any, options)
-    } else {
-      await dream.txn(txn).destroyAssociation(associationName as any, options)
+    const loaded = (dream as any)[associationName]
+    const records: Dream[] = Array.isArray(loaded) ? loaded : loaded ? [loaded] : []
+
+    for (const record of records) {
+      if (reallyDestroy) {
+        await (record as any).txn(txn).reallyDestroy(options)
+      } else {
+        await (record as any).txn(txn).destroy(options)
+      }
     }
   }
 }

--- a/src/dream/internal/destroyDream.ts
+++ b/src/dream/internal/destroyDream.ts
@@ -3,6 +3,7 @@ import Dream from '../../Dream.js'
 import DreamTransaction from '../DreamTransaction.js'
 import destroyAssociatedRecords from './destroyAssociatedRecords.js'
 import { DestroyOptions as OptionalDestroyOptions } from './destroyOptions.js'
+import loadDependentDestroyTree from './loadDependentDestroyTree.js'
 import runHooksFor from './runHooksFor.js'
 
 type DestroyOptions<DreamInstance extends Dream> = Required<OptionalDestroyOptions<DreamInstance>>
@@ -50,7 +51,12 @@ async function destroyDreamWithTransaction<I extends Dream>(
   const { cascade, reallyDestroy, skipHooks } = options
 
   if (cascade) {
-    await destroyAssociatedRecords(dream, txn, options)
+    const dreamWithAssociations = await loadDependentDestroyTree(dream, txn, {
+      reallyDestroy,
+      bypassAllDefaultScopes: options.bypassAllDefaultScopes ?? false,
+      defaultScopesToBypass: (options.defaultScopesToBypass ?? []) as string[],
+    })
+    await destroyAssociatedRecords(dreamWithAssociations, txn, options)
   }
 
   if (!skipHooks) {

--- a/src/dream/internal/loadDependentDestroyTree.ts
+++ b/src/dream/internal/loadDependentDestroyTree.ts
@@ -1,0 +1,54 @@
+import Dream from '../../Dream.js'
+import DreamTransaction from '../DreamTransaction.js'
+import LoadBuilder from '../LoadBuilder.js'
+import buildDependentDestroyPreloadPaths from './buildDependentDestroyPreloadPaths.js'
+import convertDreamClassAndAssociationNameTupleArrayToPreloadArgs from './convertDreamClassAndAssociationNameTupleArrayToPreloadArgs.js'
+
+/**
+ * @internal
+ *
+ * Loads all `dependent: 'destroy'` associations onto the dream instance
+ * upfront, eliminating N+1 queries during cascade destruction.
+ *
+ * Returns a clone of the dream with all associations loaded.
+ * If there are no dependent-destroy associations, returns the original dream.
+ */
+export default async function loadDependentDestroyTree<I extends Dream>(
+  dream: I,
+  txn: DreamTransaction<I>,
+  {
+    reallyDestroy,
+    bypassAllDefaultScopes,
+    defaultScopesToBypass,
+  }: {
+    reallyDestroy: boolean
+    bypassAllDefaultScopes: boolean
+    defaultScopesToBypass: string[]
+  }
+): Promise<I> {
+  const dreamClass = dream.constructor as typeof Dream
+  const paths = buildDependentDestroyPreloadPaths(dreamClass)
+
+  if (paths.length === 0) return dream
+
+  let loadBuilder = new LoadBuilder<I>(dream, txn)
+
+  for (const path of paths) {
+    const args = convertDreamClassAndAssociationNameTupleArrayToPreloadArgs(path)
+    loadBuilder = loadBuilder.load(...(args as [any]))
+  }
+
+  if (bypassAllDefaultScopes) {
+    loadBuilder = loadBuilder.removeAllDefaultScopes()
+  } else {
+    for (const scopeName of defaultScopesToBypass) {
+      loadBuilder = loadBuilder.removeDefaultScope(scopeName as any)
+    }
+  }
+
+  if (reallyDestroy) {
+    loadBuilder = loadBuilder.removeDefaultScope('dream:SoftDelete' as any)
+  }
+
+  return await loadBuilder.execute()
+}

--- a/src/serializer/SerializerRenderer.ts
+++ b/src/serializer/SerializerRenderer.ts
@@ -225,7 +225,7 @@ export default class SerializerRenderer {
                   // does not pass it into the call to DreamSerializer/ObjectSerializer,
                   // then it would be lost to serializers rendered via rendersOne/Many, and SerializerRenderer
                   // handles passing its passthrough data into those
-                  .render(passthroughData)
+                  .render(passthroughData, this.renderOpts)
               )
             }
           )

--- a/src/serializer/builders/DreamSerializerBuilder.ts
+++ b/src/serializer/builders/DreamSerializerBuilder.ts
@@ -145,6 +145,10 @@ export default class DreamSerializerBuilder<
    *   - `default` - Value to use when the target object or its attribute is null/undefined
    *   - `openapi` - OpenAPI schema definition; required for non-Dream targets and json/jsonb
    *     columns, optional for standard Dream columns (where types are inferred)
+   *   - `optional` - Set to `true` to indicate the value can be null in the OpenAPI schema
+   *     (wraps the type in `anyOf: [schema, { type: 'null' }]`). For Dream models, this is
+   *     auto-inferred from optional BelongsTo associations. Use this when delegating through
+   *     a HasOne or other nullable association.
    *   - `precision` - Round decimal values to the specified number of decimal places (0–9)
    *     during rendering; does not affect the OpenAPI shape
    *   - `required` - Set to `false` to mark the attribute as optional in the OpenAPI schema;
@@ -199,12 +203,14 @@ export default class DreamSerializerBuilder<
       ? TargetAttributeName extends NonJsonDreamColumnNames<AssociatedModelType> &
           keyof AssociatedModelType &
           'type'
-        ? AutomaticSerializerAttributeOptionsForType
+        ? AutomaticSerializerAttributeOptionsForType | { optional?: boolean }
         : TargetAttributeName extends DreamVirtualColumns<AssociatedModelType>[number]
           ? SerializerAttributeOptionsForVirtualColumn
-          : TargetAttributeName extends AssociatedModelType & keyof AssociatedModelType & string
+          : TargetAttributeName extends NonJsonDreamColumnNames<AssociatedModelType> &
+                keyof AssociatedModelType &
+                string
             ?
-                | AutomaticSerializerAttributeOptions
+                | (AutomaticSerializerAttributeOptions & { optional?: boolean })
                 | NonAutomaticSerializerAttributeOptionsWithPossibleDecimalRenderOption
             : NonAutomaticSerializerAttributeOptionsWithPossibleDecimalRenderOption
       : NonAutomaticSerializerAttributeOptionsWithPossibleDecimalRenderOption

--- a/src/serializer/builders/DreamSerializerBuilder.ts
+++ b/src/serializer/builders/DreamSerializerBuilder.ts
@@ -181,8 +181,10 @@ export default class DreamSerializerBuilder<
       ? undefined
       : Exclude<keyof ProvidedModelType, keyof Dream>,
     ActualDataType extends ProvidedModelType extends undefined
-      ? DataType
-      : ProvidedModelType = ProvidedModelType extends undefined ? DataType : ProvidedModelType,
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType = ProvidedModelType extends undefined
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType,
     TargetName extends ProvidedTargetName extends undefined
       ? Exclude<keyof ActualDataType, keyof Dream>
       : ProvidedTargetName & keyof ActualDataType = ProvidedTargetName extends undefined
@@ -344,8 +346,10 @@ export default class DreamSerializerBuilder<
       ? undefined
       : Exclude<keyof ProvidedModelType, keyof Dream>,
     ActualDataType extends ProvidedModelType extends undefined
-      ? DataType
-      : ProvidedModelType = ProvidedModelType extends undefined ? DataType : ProvidedModelType,
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType = ProvidedModelType extends undefined
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType,
     AttributeName extends ProvidedAttributeName extends undefined
       ? Exclude<keyof ActualDataType, keyof Dream>
       : ProvidedAttributeName & keyof ActualDataType = ProvidedAttributeName extends undefined
@@ -454,8 +458,10 @@ export default class DreamSerializerBuilder<
       ? undefined
       : Exclude<keyof ProvidedModelType, keyof Dream>,
     ActualDataType extends ProvidedModelType extends undefined
-      ? DataType
-      : ProvidedModelType = ProvidedModelType extends undefined ? DataType : ProvidedModelType,
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType = ProvidedModelType extends undefined
+      ? InstanceType<DataTypeForOpenapi>
+      : ProvidedModelType,
     AttributeName extends ProvidedAttributeName extends undefined
       ? Exclude<keyof ActualDataType, keyof Dream>
       : ProvidedAttributeName & keyof ActualDataType = ProvidedAttributeName extends undefined

--- a/src/types/serializer.ts
+++ b/src/types/serializer.ts
@@ -18,7 +18,14 @@ export interface InternalAnyTypedSerializerDelegatedAttribute {
   type: 'delegatedAttribute'
   targetName: string
   name: string
-  options: Partial<NonAutomaticSerializerAttributeOptionsWithPossibleDecimalRenderOption>
+  options: {
+    as?: string
+    default?: any
+    openapi?: OpenapiSchemaBodyShorthand | OpenapiShorthandPrimitiveTypes
+    required?: false
+    precision?: RoundingPrecision
+    optional?: boolean
+  }
 }
 
 export interface InternalAnyTypedSerializerCustomAttribute {

--- a/test-app/app/models/CircularReference/ModelA.ts
+++ b/test-app/app/models/CircularReference/ModelA.ts
@@ -23,7 +23,7 @@ export default class ModelA extends ApplicationModel {
   public createdAt: DreamColumn<ModelA, 'createdAt'>
   public updatedAt: DreamColumn<ModelA, 'updatedAt'>
 
-  @deco.HasOne('CircularReference/ModelB')
+  @deco.HasOne('CircularReference/ModelB', { dependent: 'destroy' })
   public modelBChild: ModelB
 
   @deco.HasOne('CircularReference/ModelB')

--- a/test-app/app/models/CircularReference/ModelB.ts
+++ b/test-app/app/models/CircularReference/ModelB.ts
@@ -23,7 +23,7 @@ export default class ModelB extends ApplicationModel {
   public createdAt: DreamColumn<ModelB, 'createdAt'>
   public updatedAt: DreamColumn<ModelB, 'updatedAt'>
 
-  @deco.HasOne('CircularReference/ModelA')
+  @deco.HasOne('CircularReference/ModelA', { dependent: 'destroy' })
   public modelAChild: ModelA
 
   @deco.BelongsTo('CircularReference/ModelA', { optional: true })

--- a/test-app/app/models/CircularReferenceModel.ts
+++ b/test-app/app/models/CircularReferenceModel.ts
@@ -20,7 +20,7 @@ export default class CircularReferenceModel extends ApplicationModel {
   public createdAt: DreamColumn<CircularReferenceModel, 'createdAt'>
   public updatedAt: DreamColumn<CircularReferenceModel, 'updatedAt'>
 
-  @deco.HasOne('CircularReferenceModel', { on: 'parentId' })
+  @deco.HasOne('CircularReferenceModel', { on: 'parentId', dependent: 'destroy' })
   public child: CircularReferenceModel
 
   @deco.BelongsTo('CircularReferenceModel', { on: 'parentId', optional: true })


### PR DESCRIPTION
Generate the full load tree and use `.load(...).execute(...)` to avoid exponential N+1 problem during deletion cascades