### PR TITLE
WLOS-2650: Fix uniq deduplicating distinct functions with identical toString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.2
+
+- update uniq helper to not compare functions using toString
+
 ## 2.9.1
 
 - fix migration generator emitting an unprefixed `.dropColumn(...)` in the down migration for `:encrypted` attributes; the up creates `encrypted_<name>` so the down failed on rollback. Only affected `alterTable` migrations (the `createTable` path's `dropTable` masked the bug)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/helpers/uniq.spec.ts
+++ b/spec/unit/helpers/uniq.spec.ts
@@ -51,6 +51,24 @@ describe('uniq', () => {
     })
   })
 
+  context('when the elements are functions with identical toString() but different references', () => {
+    it('treats them as distinct', () => {
+      // Simulates what happens under vitest SSR transform: two different
+      // serializer functions from different modules compile to identical
+      // source text because import placeholders are numbered the same way.
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const fn1 = new Function('a', 'return a + 1')
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const fn2 = new Function('a', 'return a + 1')
+
+      // Verify precondition: same toString, different references
+      expect(fn1.toString()).toBe(fn2.toString())
+      expect(fn1).not.toBe(fn2)
+
+      expect(uniq([fn1, fn2])).toEqual([fn1, fn2])
+    })
+  })
+
   it('supports mixed types', async () => {
     const graphNode1 = await GraphNode.create({ name: 'Hello' })
     const graphNode2 = await GraphNode.findOrFail(graphNode1.id)

--- a/src/helpers/comparisonKey.ts
+++ b/src/helpers/comparisonKey.ts
@@ -3,7 +3,7 @@ import Dream from '../Dream.js'
 export default function comparisonKey<ElementType>(
   val: ElementType,
   toKey: ((a: ElementType) => string | number | bigint) | undefined = undefined
-): number | string | bigint | null | undefined {
+): number | string | bigint | null | undefined | ((...args: any[]) => any) {
   if (val instanceof Dream) return val.comparisonKey
   if (toKey) return toKey(val)
 
@@ -15,6 +15,8 @@ export default function comparisonKey<ElementType>(
     case 'string':
     case 'bigint':
       return val
+    case 'function':
+      return val as (...args: any[]) => any
     default:
       return val.toString()
   }


### PR DESCRIPTION
## Summary
#### Problem
- `comparisonKey` used `val.toString()` for functions, which under vitest's SSR transform can produce identical output for distinct serializer functions from different modules (import references get rewritten to `__vite_ssr_import_N__` placeholders).

- This caused `uniq` to incorrectly drop one of the serializers when building OpenAPI `anyOf` schemas for STI models, leading to `OpenapiResponseValidationFailure` at runtime. This can happen commonly with STI children since they will often a common type attribute definition referencing `sanitizedName` to provider a distinct openapi shape for each serializer. However, because looked the same when calling `toString` one of the STI children ends up being omitted by vitest

#### Fix 
add a `case 'function'` branch in `comparisonKey` that returns the function reference itself, so `Map` uses referential equality (`===`) instead of `toString()`.

#### Further Findings

Because vitest's SSR transform doesn't preserve the original import names. It rewrites every import in a module to numbered placeholders based on import order within that file, not based on what's being imported.

  In Serializer1.ts, the imports are:

```
  import Model1 from '...'   // 1st import → __vite_ssr_import_0__
  import { BaseSerializer } from '...'  // 2nd import → __vite_ssr_import_1__
```
  In Serializer2.ts, the imports are:
```
  import Model2 from '...'     // 1st import → __vite_ssr_import_0__
  import { BaseSerializer } from '...'  // 2nd import → __vite_ssr_import_1__
```
  Both files have the same import structure — a default model import first, then the base serializer second. So vitest assigns the same placeholder numbers to both. The compiled arrow functions both become:
```
  (model, passthroughData) => (0,__vite_ssr_import_1__.BaseSerializer)((0,__vite_ssr_import_0__.default), model, passthroughData)
```
  The __vite_ssr_import_0__ variables point to different modules at runtime (one resolves to Model1, the other to Model2), but toString() only returns the source text — it doesn't resolve the closured variable values. So the strings
  are identical.

#### Conclusion

In addition to the fix we have in this PR, we could have updated `inferSerializerFromDreamOrViewModel.ts` to stop using `uniq`.


Closes https://rvohealth.atlassian.net/browse/WLOS-2650

🤖 Generated with [Claude Code](https://claude.com/claude-code)