### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
-## 2.8.1
+## 2.9.0
 
-- gate auto-generated type/schema sync to `NODE_ENV=test`; `db:migrate`, `db:rollback`, and `sync` no longer regenerate type files in development, preventing a stale dev database from clobbering types generated under tests
-- fix typing of class decorators (`SoftDelete`, `STI`, and `ReplicaSafe`)
-- support `optional` and `required` uniformly on serializer `delegatedAttribute`
-- pass through pg `ssl` config on `SingleDbCredential`
+Security and hardening release. One behavior change worth flagging on upgrade: `Encrypt.decrypt` now throws on failure instead of returning `null` (callers branching on `=== null` should switch to catching the new typed errors).
+
 - `Encrypt.decrypt` throws typed errors (`DecryptionError`, `DecryptionParseError`, `DecryptionWithRotationError`) instead of returning `null`; key rotation failures throw rather than swallow
-- add `Encrypt.generateKey` and document the encryption key rotation workflow
-- add `ops.like.escape` for safely escaping user input in `LIKE` / `ILIKE` clauses
 - harden `DreamCLI.spawn`: always argv-form (no shell-form invocation), accepts argv via `opts.args`; route DB-types sync, doc generation, and post-sync through it to avoid shell injection; throws `SspawnRequiresDevelopmentOrTest` outside `NODE_ENV=development`/`test`, failing closed for staging-style and unforeseen environments. Backward compatible — a multi-token `command` string like `'pnpm psy sync'` is split on whitespace and prepended to any caller-supplied `opts.args` so existing call sites keep working without changes. The internal `sspawn` helper has been folded into `DreamCLI.spawn`
+- add `ops.like.escape` for safely escaping user input in `LIKE` / `ILIKE` clauses
+- gate auto-generated type/schema sync to `NODE_ENV=test`; `db:migrate`, `db:rollback`, and `sync` no longer regenerate type files in development, preventing a stale dev database from clobbering types generated under tests
+- pass through pg `ssl` config on `SingleDbCredential`
+- support `optional` and `required` uniformly on serializer `delegatedAttribute`
+- clarify `g:sti-child` help text re: migrations and soft delete
+- document the encryption key rotation workflow using `Encrypt.generateKey`
 - rewrite `SECURITY.md` with reporting flow, SLA, scope, and disclosure policy
 - add security spec suite under `spec/unit/security/`
+
+## 2.8.1
+
+- fix typing of class decorators (`SoftDelete`, `STI`, and `ReplicaSafe`)
 
 ## 2.8.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "dream orm",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump to 2.9.0 and correct the CHANGELOG: published 2.8.1 actually contained only the class-decorator typing fix (gitHead 651f7007). All other entries previously listed under 2.8.1 landed after publish and move to 2.9.0. Encrypt.decrypt now throws typed errors instead of returning null, justifying the minor bump.