### PR TITLE
Release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.1
+
+- fix migration generator emitting an unprefixed `.dropColumn(...)` in the down migration for `:encrypted` attributes; the up creates `encrypted_<name>` so the down failed on rollback. Only affected `alterTable` migrations (the `createTable` path's `dropTable` masked the bug)
+
 ## 2.9.0
 
 Security and hardening release. One behavior change worth flagging on upgrade: `Encrypt.decrypt` now throws on failure instead of returning `null` (callers branching on `=== null` should switch to catching the new typed errors).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/cli/generateMigrationContent.spec.ts
+++ b/spec/unit/cli/generateMigrationContent.spec.ts
@@ -518,6 +518,36 @@ export async function down(db: Kysely<any>): Promise<void> {
     })
 
     context('encrypted attribute', () => {
+      it('drops the prefixed encrypted column on alterTable down migrations', () => {
+        const res = generateMigrationContent({
+          table: 'users',
+          columnsWithTypes: ['phone_number:encrypted'],
+          primaryKeyType: 'bigserial',
+          createOrAlter: 'alter',
+        })
+
+        expect(res).toEqual(
+          `\
+import { Kysely, sql } from 'kysely'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('users')
+    .addColumn('encrypted_phone_number', 'text', col => col.notNull())
+    .execute()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('users')
+    .dropColumn('encrypted_phone_number')
+    .execute()
+}`
+        )
+      })
+
       it('generates a kysely migration with multiple text fields', () => {
         const res = generateMigrationContent({
           table: 'users',

--- a/src/helpers/cli/generateMigrationContent.ts
+++ b/src/helpers/cli/generateMigrationContent.ts
@@ -95,7 +95,7 @@ export default function generateMigrationContent({
         userWantsThisOptional || (!!stiChildClassName && !arrayAttribute && !isBooleanColumn)
 
       if (nonStandardAttributeName === undefined) return acc
-      let attributeName = snakeify(nonStandardAttributeName)
+      let attributeName: string = snakeify(nonStandardAttributeName)
 
       switch (processedAttrType) {
         case 'belongsto':
@@ -146,8 +146,9 @@ export default function generateMigrationContent({
           break
 
         case 'encrypted':
+          attributeName = `encrypted_${attributeName}`
           columnDefs.push(
-            generateColumnStr(`encrypted_${attributeName}`, 'text', descriptors, {
+            generateColumnStr(attributeName, 'text', descriptors, {
               omitInlineNonNull,
             })
           )


### PR DESCRIPTION
Fix migration generator emitting an unprefixed `.dropColumn(...)` in the down migration for `:encrypted` attributes. Up creates `encrypted_<name>`, so rollback failed. Only affected `alterTable` migrations — the `createTable` path's `dropTable` masked the bug.