### PR TITLE
refactor(migration): align inverted enum-array interface names with behavior

### DIFF
--- a/src/db/migration-helpers/DreamMigrationHelpers.ts
+++ b/src/db/migration-helpers/DreamMigrationHelpers.ts
@@ -348,13 +348,13 @@ interface DropValueFromEnumTablesAndColumnsForArrayBase {
 
 interface DropValueWithRemovalFromEnumTablesAndColumnsForArray
   extends DropValueFromEnumTablesAndColumnsForArrayBase {
-  behavior: 'replace'
-  replaceWith: string
+  behavior: 'remove'
 }
 
 interface DropValueWithReplacementFromEnumTablesAndColumnsForArray
   extends DropValueFromEnumTablesAndColumnsForArrayBase {
-  behavior: 'remove'
+  behavior: 'replace'
+  replaceWith: string
 }
 
 type DropValueFromEnumTablesAndColumnsForArray =

--- a/src/ops/index.ts
+++ b/src/ops/index.ts
@@ -52,7 +52,7 @@ const ops = {
    * @example
    * User.where({ status: ops.in(['active', 'pending']) })
    */
-  in: <const T extends unknown[]>(arr: T) => new OpsStatement<'in', T[number]>('in', arr as T[number]),
+  in: <const T extends unknown[]>(arr: T) => new OpsStatement<'in', T[number]>('in', arr),
 
   /**
    * Creates a `CurriedOpsStatement` that checks whether a PostgreSQL array column contains


### PR DESCRIPTION
## Problem

In `DreamMigrationHelpers`, the two array-column variants of `DropValueFromEnumTablesAndColumns` had names that were swapped relative to their `behavior` discriminant:

```ts
interface DropValueWithRemovalFromEnumTablesAndColumnsForArray ... {
  behavior: 'replace'   // <- "Removal" interface, but the replace path
  replaceWith: string
}
interface DropValueWithReplacementFromEnumTablesAndColumnsForArray ... {
  behavior: 'remove'    // <- "Replacement" interface, but the remove path
}
```

A maintainer reading `WithRemoval` reasonably expects `array_remove`, but it actually carries the `array_replace` path (and vice-versa). Confusing and a maintenance hazard.

## Fix

Swap the interface bodies so each name matches its `behavior`. These types are **internal** (not exported), and the public discriminated shape on `dropEnumValue`'s `replacements` is unchanged:

- `behavior: 'replace'` still requires `replaceWith`
- `behavior: 'remove'` still omits it

No runtime change — TypeScript interfaces are erased. No spec needed (no behavior change). Full gauntlet (`lint`, `build:test-app`, `spec`) passes.

> Stacked on #708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)