### PR TITLE
refactor(ops): drop misleading value cast in ops.in

### DIFF
--- a/src/ops/index.ts
+++ b/src/ops/index.ts
@@ -52,7 +52,7 @@ const ops = {
    * @example
    * User.where({ status: ops.in(['active', 'pending']) })
    */
-  in: <const T extends unknown[]>(arr: T) => new OpsStatement<'in', T[number]>('in', arr as T[number]),
+  in: <const T extends unknown[]>(arr: T) => new OpsStatement<'in', T[number]>('in', arr),
 
   /**
    * Creates a `CurriedOpsStatement` that checks whether a PostgreSQL array column contains


### PR DESCRIPTION
## Problem

`ops.in` passed its array argument with a misleading cast:

```ts
in: <const T extends unknown[]>(arr: T) =>
  new OpsStatement<'in', T[number]>('in', arr as T[number]),
```

`arr as T[number]` asserts the array *is* one element. It's only a type-level lie — at runtime the whole `arr` is passed (which is correct for an `IN (...)` clause). The sibling `ops.not.in` already does the right thing with a plain `arr`:

```ts
in: <const T extends unknown[]>(arr: T) =>
  new OpsStatement<'not in', T[number]>('not in', arr),
```

The cast served no purpose and obscured that `in` and `not in` build identical statements.

## Fix

Pass `arr` directly, matching `ops.not.in`. The test app still builds (`build:test-app` green), confirming the cast was unnecessary. No runtime change. Full gauntlet (`lint`, `build:test-app`, `spec`) passes.

> Stacked on #709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)