### PR TITLE
fix(lint): clear all lint warnings and forbid warnings in PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,23 @@ Rules:
 - If a command takes a long time, wait for it. Do not assume it would have
   passed.
 
+## Changelog and Versioning
+
+Every **user-facing** change needs a version bump and a corresponding
+`CHANGELOG.md` entry. A change is user-facing if a consumer of the published
+package can observe it: runtime behavior, public/exported API or types,
+generated output, error messages, deprecations, or peer-dependency
+requirements.
+
+The changelog is written for consumers of the package, so it must **not**
+document fully internal changes — refactors, renames of unexported symbols,
+internal type-annotation cleanups, comment/doc edits, test-only changes, and
+anything else with no observable effect on a consumer. These still ship, but
+they get neither a changelog entry nor (on their own) a version bump.
+
+When in doubt, ask: "could someone who only installs the npm package tell this
+happened?" If no, keep it out of the changelog.
+
 ## Database Commands
 
 ### Migrate the Database

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ pnpm spec
 Rules:
 
 - **Never** push or open a PR if any of the three fail. Fix the failure first.
+- **Zero lint warnings.** `pnpm lint` must exit clean — no errors _and_ no
+  warnings. ESLint warnings (e.g. unused `eslint-disable` directives) do not
+  fail the command's exit code on their own, so read the output: if the summary
+  reports any warnings, the gauntlet has NOT passed. Most are auto-fixable by
+  re-running the lint command with `--fix` added to the `eslint` invocation,
+  followed by `pnpm format`. A PR must never introduce a new lint warning.
 - **Never** trust a previous run — re-run the gauntlet after every change you
   make in response to a failure, including formatter/lint auto-fixes.
 - `pnpm spec` (full suite) is required. Targeted `pnpm spec <path>` runs skip

--- a/spec/unit/db/dbConnectionLeakDiagnostics.spec.ts
+++ b/spec/unit/db/dbConnectionLeakDiagnostics.spec.ts
@@ -18,15 +18,12 @@ import {
 // real shutdown-hang reproduction; mocking pg.Pool's async connect here would
 // only test the mock.
 describe('db connection leak diagnostics (disabled by default)', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
   const Pool = (pg as any).Pool
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const pristineConnect = Pool.prototype.connect
 
   it('does not patch pg.Pool.prototype.connect (no NODE_DEBUG=dream in the test process)', () => {
     installDbConnectionLeakDiagnosticsIfEnabled()
     installDbConnectionLeakDiagnosticsIfEnabled() // idempotent / safe to repeat
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(Pool.prototype.connect).toBe(pristineConnect)
   })
 

--- a/spec/unit/utils/datetime/DateTime.spec.ts
+++ b/spec/unit/utils/datetime/DateTime.spec.ts
@@ -876,7 +876,6 @@ describe('DateTime', () => {
     it('reflects UTC (not local) when coerced against a primitive', () => {
       const ny = DateTime.fromISO('2026-02-07T09:00:00.123456-05:00')
       // `==` against a primitive coerces the DateTime via valueOf (UTC), unlike object-to-object `==`
-      // eslint-disable-next-line eqeqeq
       expect((ny as unknown) == '2026-02-07T14:00:00.123456Z').toBe(true)
     })
 

--- a/src/db/dbConnectionLeakDiagnostics.ts
+++ b/src/db/dbConnectionLeakDiagnostics.ts
@@ -52,19 +52,13 @@ function track(client: object | undefined, stack: string | undefined): void {
   if (!client) return
   checkedOutClients.set(client, { stack: stack ?? '(no stack captured)', since: Date.now() })
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const c = client as any
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (c.__dreamReleasePatched) return
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const originalRelease = c.release
   if (typeof originalRelease !== 'function') return
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   c.__dreamReleasePatched = true
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   c.release = function patchedRelease(...args: unknown[]) {
     checkedOutClients.delete(client)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
     return originalRelease.apply(this, args)
   }
 }
@@ -77,36 +71,27 @@ export function installDbConnectionLeakDiagnosticsIfEnabled(): void {
   if (!dreamDebugEnabled) return
   enabled = true
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   const Pool = (pg as any).Pool
   if (!Pool?.prototype) return
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (Pool.prototype[INSTALLED]) return
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   Pool.prototype[INSTALLED] = true
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
   const originalConnect = Pool.prototype.connect
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   Pool.prototype.connect = function patchedConnect(cb?: unknown) {
     const acquireStack = new Error('db connection acquired here').stack
 
     if (typeof cb === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
       return originalConnect.call(this, (err: unknown, client: object | undefined, release: unknown) => {
         track(client, acquireStack)
         // `track()` replaces `client.release` with an untracking wrapper.
         // Callback-style users call the 3rd `release` arg, which pg captured
         // *before* that swap — so hand them the wrapped one instead, or a
         // correctly-released client would be reported as a false leak.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
         const wrappedRelease = client ? (client as any).release : release
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         ;(cb as (e: unknown, c: unknown, r: unknown) => void)(err, client, wrappedRelease)
       })
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     return originalConnect.call(this).then((client: object) => {
       track(client, acquireStack)
       return client


### PR DESCRIPTION
## Summary

- Removes all 19 lint warnings (unused `eslint-disable` directives in the db connection-leak diagnostics module and its spec, plus one in the DateTime spec). The disabled rules weren't firing, so the directives were dead.
- Documents a **zero lint warnings** rule in the AGENTS.md completion gauntlet — ESLint warnings don't change the command's exit code, so they could previously slip into a PR. The gauntlet now requires `pnpm lint` output to be warning-free.
- Cherry-picks `7d4cb82` (changelog/versioning policy in AGENTS.md).

No version bump or changelog entry: all changes are internal/test-only/docs and not observable by package consumers, per the cherry-picked changelog policy.

## Test plan

Full completion gauntlet run and passing:
- `pnpm lint` — clean, zero warnings
- `pnpm build:test-app` — passes
- `pnpm spec` — 3162 passed, 96 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)