### PR TITLE
Preserve param-safe virtual attribute types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.14.1
+
+- `DreamParamSafeAttributes` now preserves concrete model-declared types for virtual columns, including `@Encrypted` properties, instead of exposing those param-safe attributes as `any`. Database-backed and association param types continue to use Dream's existing updateable-property typing; only the virtual-column `any` fallback is replaced by the model property type.
+
 ## 2.14.0
 
 - Eliminate the intermittent parallel-test database collision by claiming each live test worker its own database from a pre-created pool via a process-lifetime lock the database driver supplies through the query-driver seam, replacing the `<base>_<VITEST_POOL_ID>` naming. Under vitest (`pool: 'forks'`, `isolate: true`) `VITEST_POOL_ID` is a _reusable_ slot id (1..maxWorkers) that vitest frees and reassigns across worker processes without awaiting `runner.stop()`, so a retired-but-still-terminating worker overlaps the new worker that reused its slot. Keying the test database off that slot meant the two overlapping processes shared one database and the newcomer's `beforeEach(truncate)` wiped the other's in-flight rows — a record created in a test's setup would vanish before the request under test ran, producing intermittent 404s / empty lists / wrong results (~1 run in 3, and it reproduced serially too because vitest respawns a process per file even with one worker). The fix ties database ownership to _process liveness_ instead of vitest's slot accounting:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "dream orm",
   "repository": {
     "type": "git",

--- a/spec/unit/dream/paramSafeColumnsOrFallback.spec.ts
+++ b/spec/unit/dream/paramSafeColumnsOrFallback.spec.ts
@@ -1,4 +1,4 @@
-import { DreamParamUnsafeColumnNames } from '../../../src/types/dream.js'
+import { DreamParamSafeAttributes, DreamParamUnsafeColumnNames } from '../../../src/types/dream.js'
 import Balloon from '../../../test-app/app/models/Balloon.js'
 import Latex from '../../../test-app/app/models/Balloon/Latex.js'
 import LocalizedText from '../../../test-app/app/models/LocalizedText.js'
@@ -12,6 +12,9 @@ import User from '../../../test-app/app/models/User.js'
 
 describe('Dream#paramSafeColumnsOrFallback', () => {
   context('type tests', () => {
+    type IsAny<T> = 0 extends 1 & T ? true : false
+    type ExpectFalse<T extends false> = T
+
     // intentionally skipped, this should cause build:test-app
     // to fail unless the types are correctly lining up.
     it.skip('includes fields that are safe for updating', () => {
@@ -33,6 +36,34 @@ describe('Dream#paramSafeColumnsOrFallback', () => {
         case 'type':
         case 'localizableType':
       }
+    })
+
+    it.skip('preserves concrete types for virtual and encrypted param-safe attributes', () => {
+      type UserParamSafeAttributes = DreamParamSafeAttributes<User>
+      type PasswordIsNotAny = ExpectFalse<IsAny<UserParamSafeAttributes['password']>>
+      type SecretIsNotAny = ExpectFalse<IsAny<UserParamSafeAttributes['secret']>>
+      type OtherSecretIsNotAny = ExpectFalse<IsAny<UserParamSafeAttributes['otherSecret']>>
+
+      const password: string | undefined = null as unknown as UserParamSafeAttributes['password']
+      const secret: string | null = null as unknown as UserParamSafeAttributes['secret']
+      const otherSecret: { token: string } | null = null as unknown as UserParamSafeAttributes['otherSecret']
+
+      // @ts-expect-error virtual params are not `any`
+      const invalidPassword: number = null as unknown as UserParamSafeAttributes['password']
+      // @ts-expect-error encrypted params are not `any`
+      const invalidSecret: number = null as unknown as UserParamSafeAttributes['secret']
+      // @ts-expect-error encrypted params with explicit value types are not `any`
+      const invalidOtherSecret: number = null as unknown as UserParamSafeAttributes['otherSecret']
+
+      void (null as unknown as PasswordIsNotAny)
+      void (null as unknown as SecretIsNotAny)
+      void (null as unknown as OtherSecretIsNotAny)
+      void password
+      void secret
+      void otherSecret
+      void invalidPassword
+      void invalidSecret
+      void invalidOtherSecret
     })
   })
 

--- a/src/types/dream.ts
+++ b/src/types/dream.ts
@@ -298,9 +298,16 @@ export type DreamAttributeDbTypes<
 }
 
 export type DreamParamSafeAttributes<DreamInstance extends Dream> = {
-  [K in keyof UpdateableProperties<DreamInstance> &
-    DreamParamSafeColumnNames<DreamInstance>]: UpdateableProperties<DreamInstance>[K]
+  [K in keyof UpdateableProperties<DreamInstance> & DreamParamSafeColumnNames<DreamInstance>]: IsAny<
+    UpdateableProperties<DreamInstance>[K]
+  > extends true
+    ? K extends keyof DreamInstance
+      ? DreamInstance[K]
+      : UpdateableProperties<DreamInstance>[K]
+    : UpdateableProperties<DreamInstance>[K]
 }
+
+type IsAny<T> = 0 extends 1 & T ? true : false
 
 export type DreamTableSchema<DreamInstance extends Dream> = Updateable<
   DreamInstance['DB'][DreamInstance['table']]


### PR DESCRIPTION
## Summary
- Preserve concrete model-declared types for virtual param-safe attributes, including encrypted properties, instead of exposing them as any.
- Add a compile-time spec covering virtual and encrypted param-safe attributes.
- Bump Dream to 2.14.1 and add a changelog entry.

## Verification
- CI=1 pnpm lint
- pnpm build:test-app
- pnpm spec