### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.16.0
+## 2.15.1
 
 - switch to Github action publishing to npmjs.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.16.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 2.15.0
 
 - Required `BelongsTo` association getters now throw `MissingRequiredBelongsToAssociation` when the association has been loaded as `null`. This replaces a confusing null dereference path with a diagnostic error that names the model, association, foreign key, and, for polymorphic associations, the polymorphic type field. Optional `BelongsTo` associations still return `null`, and associations that have not been loaded still throw `NonLoadedAssociation`. When the foreign key is present but the association loads as `null`, the message calls out that the associated record may have been deleted and suggests checking whether the inverse `HasOne`/`HasMany` association should specify `dependent: 'destroy'`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.16.0",
+  "version": "2.15.1",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bumps the minor package version for GitHub releases and signed provenance when publishing to npmjs.com.