### PR TITLE
fix: upgrade to pnpm 11.9.0, deny esbuild build script in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.15.2
+
+- upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild build scripts in pnpm-workspace.yaml
+
 ## 2.15.1
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"
@@ -115,5 +115,5 @@
     "vitest": "^4.1.0",
     "winston": "^3.14.2"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,13 +9,14 @@ overrides:
   # ranges with no override needed.
   esbuild: '>=0.28.1'
 
+strictDepBuilds: false
 # SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
 # dependency lifecycle scripts (postinstall, etc.) by default; that default is
 # the primary defense against Shai-Hulud-class npm worms. Only packages listed
 # below (= true) may run install/build scripts. Keep this MINIMAL — every entry
 # re-opens script execution for that package, so add one only with clear cause.
 allowBuilds:
-  esbuild: true
+  esbuild: false
 
 minimumReleaseAgeExclude:
   - '@rvoh/dream-spec-helpers@2.2.0'


### PR DESCRIPTION
## Summary

- Upgrades `packageManager` to `pnpm@11.9.0`
- Adds `strictDepBuilds: false` to `pnpm-workspace.yaml` to satisfy pnpm 11's hard-error on undeclared build-script deps
- Changes `esbuild: true` → `esbuild: false` in `allowBuilds` — esbuild ships prebuilt binaries via optional deps and does not need its postinstall script to run
- Patch version bump to `2.15.2`

## Why esbuild: false is safe

esbuild's postinstall script downloads a platform-specific binary. The binary is already included as an optional dependency (e.g. `@esbuild/darwin-arm64`), so the install script is redundant when optional deps are resolved. Denying it closes the script-execution surface with no functional impact.

## Test plan

- [ ] `pnpm install` completes without `ERR_PNPM_IGNORED_BUILDS`
- [ ] Build and test suite pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x