### PR TITLE
Enforce STI child association rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.16.0
+
+- STI children now fail boot if they define associations that are not available on the STI base class. This enforces the intended `StiChildCannotDefineNewAssociations` rule during Dream's decorator initialization pass, where field association decorators have actually registered their metadata. Move any `@deco.BelongsTo`, `@deco.HasOne`, or `@deco.HasMany` declarations from STI children to the STI base class.
+
 ## 2.15.2
 
 - upgrade to pnpm@11.9.0; add strictDepBuilds: false and deny esbuild build scripts in pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.15.2",
+  "version": "2.16.0",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"

--- a/spec/helpers/processDynamicallyDefinedModels.ts
+++ b/spec/helpers/processDynamicallyDefinedModels.ts
@@ -1,9 +1,14 @@
 import Dream from '../../src/Dream.js'
+import { validateStiChildAssociations } from '../../src/decorators/class/STI.js'
 
 export default function processDynamicallyDefinedModels(...dreamClasses: (typeof Dream)[]) {
   Dream['globallyInitializingDecorators'] = true
-  dreamClasses.forEach(modelClass => {
-    new modelClass({}, { _internalUseOnly: true })
-  })
-  Dream['globallyInitializingDecorators'] = false
+  try {
+    dreamClasses.forEach(modelClass => {
+      new modelClass({}, { _internalUseOnly: true })
+    })
+    validateStiChildAssociations(dreamClasses)
+  } finally {
+    Dream['globallyInitializingDecorators'] = false
+  }
 }

--- a/spec/unit/dream/paramSafeColumnsOrFallback.spec.ts
+++ b/spec/unit/dream/paramSafeColumnsOrFallback.spec.ts
@@ -96,15 +96,9 @@ describe('Dream#paramSafeColumnsOrFallback', () => {
     expect(Pet.paramSafeColumnsOrFallback()).not.toEqual(expect.arrayContaining(['userId']))
   })
 
-  it(
-    'omits association foreign keys defined on STI siblings ' +
-      '(so that associations may be defined on STI children without opening up the ' +
-      'column to being set directly from params when a different sibling is specified ' +
-      'in the OpenAPI decorator in Psychic)',
-    () => {
-      expect(StiB.paramSafeColumnsOrFallback()).not.toEqual(expect.arrayContaining(['petId']))
-    }
-  )
+  it('omits association foreign keys inherited from an STI base class', () => {
+    expect(StiB.paramSafeColumnsOrFallback()).not.toEqual(expect.arrayContaining(['petId']))
+  })
 
   it('omits type field for STI models', () => {
     expect(Latex.paramSafeColumnsOrFallback()).not.toEqual(expect.arrayContaining(['type']))
@@ -118,17 +112,11 @@ describe('Dream#paramSafeColumnsOrFallback', () => {
     expect(Rating.paramSafeColumnsOrFallback()).not.toEqual(expect.arrayContaining(['rateableType']))
   })
 
-  it(
-    'omits association foreign keys defined on STI siblings ' +
-      '(so that associations may be defined on STI children without opening up the ' +
-      'column to being set directly from params when a different sibling is specified ' +
-      'in the OpenAPI decorator in Psychic)',
-    () => {
-      const results = StiA.paramSafeColumnsOrFallback()
-      expect(results).not.toEqual(expect.arrayContaining(['taskableId']))
-      expect(results).not.toEqual(expect.arrayContaining(['taskableType']))
-    }
-  )
+  it('omits polymorphic association foreign keys inherited from an STI base class', () => {
+    const results = StiA.paramSafeColumnsOrFallback()
+    expect(results).not.toEqual(expect.arrayContaining(['taskableId']))
+    expect(results).not.toEqual(expect.arrayContaining(['taskableType']))
+  })
 
   context('#paramSafeColumns is defined on the model', () => {
     class User2 extends User {

--- a/spec/unit/dream/scope/STI.spec.ts
+++ b/spec/unit/dream/scope/STI.spec.ts
@@ -1,8 +1,14 @@
+import Decorators from '../../../../src/decorators/Decorators.js'
+import STI from '../../../../src/decorators/class/STI.js'
 import { findExtendingDreamClass } from '../../../../src/dream/internal/sqlResultToDreamInstance.js'
+import StiChildCannotDefineNewAssociations from '../../../../src/errors/sti/StiChildCannotDefineNewAssociations.js'
+import processDynamicallyDefinedModels from '../../../helpers/processDynamicallyDefinedModels.js'
 import Balloon from '../../../../test-app/app/models/Balloon.js'
 import Latex from '../../../../test-app/app/models/Balloon/Latex.js'
 import Animal from '../../../../test-app/app/models/Balloon/Latex/Animal.js'
 import Mylar from '../../../../test-app/app/models/Balloon/Mylar.js'
+import Pet from '../../../../test-app/app/models/Pet.js'
+import StiBase from '../../../../test-app/app/models/Sti/Base.js'
 import User from '../../../../test-app/app/models/User.js'
 
 describe('Dream STI', () => {
@@ -156,6 +162,24 @@ describe('Dream STI', () => {
 
     const balloon = await Balloon.first()
     expect(balloon).toMatchDreamModel(mylar)
+  })
+
+  context('when an STI child defines a new association', () => {
+    it('raises a targeted exception during decorator initialization', () => {
+      class DynamicStiBase extends StiBase {}
+
+      const deco = new Decorators<typeof InvalidStiChildAssociation>()
+
+      @STI(DynamicStiBase)
+      class InvalidStiChildAssociation extends DynamicStiBase {
+        @deco.BelongsTo('Pet', { on: 'petId' })
+        public invalidPet: Pet
+      }
+
+      expect(() => processDynamicallyDefinedModels(DynamicStiBase, InvalidStiChildAssociation)).toThrow(
+        StiChildCannotDefineNewAssociations
+      )
+    })
   })
 
   describe('findExtendingDreamClass', () => {

--- a/src/decorators/class/STI.ts
+++ b/src/decorators/class/STI.ts
@@ -2,6 +2,7 @@ import Dream from '../../Dream.js'
 import StiChildCannotDefineNewAssociations from '../../errors/sti/StiChildCannotDefineNewAssociations.js'
 import StiChildIncompatibleWithReplicaSafeDecorator from '../../errors/sti/StiChildIncompatibleWithReplicaSafeDecorator.js'
 import StiChildIncompatibleWithSoftDeleteDecorator from '../../errors/sti/StiChildIncompatibleWithSoftDeleteDecorator.js'
+import { AssociationStatement, AssociationStatementsMap } from '../../types/associations/shared.js'
 import { scopeImplementation } from '../static-method/Scope.js'
 
 export const STI_SCOPE_NAME = 'dream:STI'
@@ -9,9 +10,6 @@ export const STI_SCOPE_NAME = 'dream:STI'
 export default function STI(dreamClass: typeof Dream) {
   return function (stiChildClass: typeof Dream): void {
     const baseClass = dreamClass['sti'].baseClass || dreamClass
-
-    if (Object.getOwnPropertyDescriptor(stiChildClass, 'associationMetadataByType'))
-      throw new StiChildCannotDefineNewAssociations(baseClass, stiChildClass)
 
     if (Object.getOwnPropertyDescriptor(stiChildClass, 'replicaSafe'))
       throw new StiChildIncompatibleWithReplicaSafeDecorator(stiChildClass)
@@ -34,4 +32,39 @@ export default function STI(dreamClass: typeof Dream) {
 
     scopeImplementation(stiChildClass, STI_SCOPE_NAME, { default: true })
   }
+}
+
+export function validateStiChildAssociations(dreamClasses: (typeof Dream)[]) {
+  dreamClasses.forEach(dreamClass => {
+    if (!dreamClass?.isDream) return
+    if (!dreamClass['sti'].active) return
+
+    const baseClass = dreamClass['sti'].baseClass
+    if (!baseClass) return
+    if (hasAssociationsUnavailableOnBase(baseClass, dreamClass))
+      throw new StiChildCannotDefineNewAssociations(baseClass, dreamClass)
+  })
+}
+
+function hasAssociationsUnavailableOnBase(baseClass: typeof Dream, stiChildClass: typeof Dream) {
+  const baseAssociationKeys = associationKeysByTypeAndName(baseClass['associationMetadataByType'])
+  const childAssociationKeys = associationKeysByTypeAndName(stiChildClass['associationMetadataByType'])
+
+  for (const associationKey of childAssociationKeys) {
+    if (!baseAssociationKeys.has(associationKey)) return true
+  }
+
+  return false
+}
+
+function associationKeysByTypeAndName(associationMetadataByType: AssociationStatementsMap) {
+  const res = new Set<string>()
+
+  Object.entries(associationMetadataByType).forEach(([associationType, associations]) => {
+    associations.forEach((association: AssociationStatement) => {
+      res.add(`${associationType}:${association.as}`)
+    })
+  })
+
+  return res
 }

--- a/src/dream-app/helpers/importers/importModels.ts
+++ b/src/dream-app/helpers/importers/importModels.ts
@@ -1,4 +1,5 @@
 import Dream from '../../../Dream.js'
+import { validateStiChildAssociations } from '../../../decorators/class/STI.js'
 import DreamMissingRequiredOverride from '../../../errors/DreamMissingRequiredOverride.js'
 import DreamImporter from '../DreamImporter.js'
 import globalModelKeyFromPath from '../globalModelKeyFromPath.js'
@@ -62,6 +63,8 @@ export default async function importModels(
       }
     }
   }
+
+  validateStiChildAssociations(modelClasses.map(([, modelClass]) => modelClass))
 
   /**
    * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)

--- a/src/dream-app/helpers/importers/importModels.ts
+++ b/src/dream-app/helpers/importers/importModels.ts
@@ -5,13 +5,26 @@ import DreamImporter from '../DreamImporter.js'
 import globalModelKeyFromPath from '../globalModelKeyFromPath.js'
 
 let _models: Record<string, typeof Dream>
+let _importModelsPromise: Promise<Record<string, typeof Dream>> | undefined
 
 export default async function importModels(
   modelsPath: string,
   modelImportCb: (path: string) => Promise<any>
 ): Promise<Record<string, typeof Dream>> {
   if (_models) return _models
+  if (_importModelsPromise) return await _importModelsPromise
 
+  _importModelsPromise = importModelsUncached(modelsPath, modelImportCb).finally(() => {
+    _importModelsPromise = undefined
+  })
+
+  return await _importModelsPromise
+}
+
+async function importModelsUncached(
+  modelsPath: string,
+  modelImportCb: (path: string) => Promise<any>
+): Promise<Record<string, typeof Dream>> {
   const modelClasses = await DreamImporter.importDreams(modelsPath, modelImportCb)
 
   /**
@@ -22,62 +35,67 @@ export default async function importModels(
    */
   Dream['globallyInitializingDecorators'] = true
 
-  _models = {}
+  const models: Record<string, typeof Dream> = {}
 
-  for (const [modelPath, modelClass] of modelClasses) {
-    // `?` in case modelClass is undefined (e.g. a file without a default export exists in the models directory hierarchy)
-    if (modelClass?.isDream) {
-      try {
-        // Don't create a global lookup for ApplicationModel
-        // ApplicationModel does not have a table
-        if (modelClass.table) {
-          modelClass['defineAttributeAccessors']()
+  try {
+    for (const [modelPath, modelClass] of modelClasses) {
+      // `?` in case modelClass is undefined (e.g. a file without a default export exists in the models directory hierarchy)
+      if (modelClass?.isDream) {
+        try {
+          // Don't create a global lookup for ApplicationModel
+          // ApplicationModel does not have a table
+          if (modelClass.table) {
+            modelClass['defineAttributeAccessors']()
 
-          const modelKey = globalModelKeyFromPath(modelPath, modelsPath)
-          modelClass['setGlobalName'](modelKey)
-          _models[modelKey] = modelClass
+            const modelKey = globalModelKeyFromPath(modelPath, modelsPath)
+            modelClass['setGlobalName'](modelKey)
+            models[modelKey] = modelClass
+          }
+        } catch (error) {
+          // ApplicationModel will automatically raise an exception here,
+          // since it does not have a table.
+          if (!(error instanceof DreamMissingRequiredOverride)) throw error
         }
-      } catch (error) {
-        // ApplicationModel will automatically raise an exception here,
-        // since it does not have a table.
-        if (!(error instanceof DreamMissingRequiredOverride)) throw error
       }
     }
-  }
 
-  for (const [, modelClass] of modelClasses) {
-    // `?` in case modelClass is undefined (e.g. a file without a default export exists in the models directory hierarchy)
-    if (modelClass?.isDream) {
-      try {
-        /**
-         * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)
-         * need static access to things set up by decorators (e.g. associations). Stage 3 Decorators change the context that is available
-         * at decoration time such that the class of a property being decorated is only avilable during instance instantiation. In order
-         * to only apply static values once, on boot, `globallyInitializingDecorators` is set to true on Dream, and all Dream models are instantiated.
-         */
-        new modelClass({}, { _internalUseOnly: true })
-      } catch (error) {
-        // ApplicationModel will automatically raise an exception here,
-        // since it does not have a table.
-        if (!(error instanceof DreamMissingRequiredOverride)) throw error
+    for (const [, modelClass] of modelClasses) {
+      // `?` in case modelClass is undefined (e.g. a file without a default export exists in the models directory hierarchy)
+      if (modelClass?.isDream) {
+        try {
+          /**
+           * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)
+           * need static access to things set up by decorators (e.g. associations). Stage 3 Decorators change the context that is available
+           * at decoration time such that the class of a property being decorated is only avilable during instance instantiation. In order
+           * to only apply static values once, on boot, `globallyInitializingDecorators` is set to true on Dream, and all Dream models are instantiated.
+           */
+          new modelClass({}, { _internalUseOnly: true })
+        } catch (error) {
+          // ApplicationModel will automatically raise an exception here,
+          // since it does not have a table.
+          if (!(error instanceof DreamMissingRequiredOverride)) throw error
+        }
       }
     }
+
+    validateStiChildAssociations(modelClasses.map(([, modelClass]) => modelClass))
+
+    _models = models
+
+    return _models
+  } finally {
+    /**
+     * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)
+     * need static access to things set up by decorators (e.g. associations). Stage 3 Decorators change the context that is available
+     * at decoration time such that the class of a property being decorated is only avilable during instance instantiation. In order
+     * to only apply static values once, on boot, `globallyInitializingDecorators` is set to true on Dream, and all Dream models are instantiated.
+     */
+    Dream['globallyInitializingDecorators'] = false
   }
-
-  validateStiChildAssociations(modelClasses.map(([, modelClass]) => modelClass))
-
-  /**
-   * Certain features (e.g. passing a Dream instance to `create` so that it automatically destructures polymorphic type and primary key)
-   * need static access to things set up by decorators (e.g. associations). Stage 3 Decorators change the context that is available
-   * at decoration time such that the class of a property being decorated is only avilable during instance instantiation. In order
-   * to only apply static values once, on boot, `globallyInitializingDecorators` is set to true on Dream, and all Dream models are instantiated.
-   */
-  Dream['globallyInitializingDecorators'] = false
-
-  return _models
 }
 
 export function setCachedModels(models: Record<string, typeof Dream>) {
+  _importModelsPromise = undefined
   _models = models
 }
 

--- a/test-app/app/models/Sti/A.ts
+++ b/test-app/app/models/Sti/A.ts
@@ -1,10 +1,6 @@
 import STI from '../../../../src/decorators/class/STI.js'
-import Decorators from '../../../../src/decorators/Decorators.js'
-import { DreamColumn, DreamSerializers } from '../../../../src/types/dream.js'
-import Pet from '../Pet.js'
+import { DreamSerializers } from '../../../../src/types/dream.js'
 import StiBase from './Base.js'
-
-const deco = new Decorators<typeof StiA>()
 
 @STI(StiBase)
 export default class StiA extends StiBase {
@@ -14,8 +10,4 @@ export default class StiA extends StiBase {
       summary: 'Sti/ASummarySerializer',
     }
   }
-
-  @deco.BelongsTo('Pet', { on: 'petId' })
-  public pet: Pet
-  public petId: DreamColumn<StiA, 'petId'>
 }

--- a/test-app/app/models/Sti/B.ts
+++ b/test-app/app/models/Sti/B.ts
@@ -1,12 +1,6 @@
 import STI from '../../../../src/decorators/class/STI.js'
-import Decorators from '../../../../src/decorators/Decorators.js'
-import { DreamColumn, DreamSerializers } from '../../../../src/types/dream.js'
-import Chore from '../Polymorphic/Chore.js'
-import TaskableImage from '../Polymorphic/TaskableImage.js'
-import Workout from '../Polymorphic/Workout.js'
+import { DreamSerializers } from '../../../../src/types/dream.js'
 import StiBase from './Base.js'
-
-const deco = new Decorators<typeof StiB>()
 
 @STI(StiBase)
 export default class StiB extends StiBase {
@@ -16,12 +10,4 @@ export default class StiB extends StiBase {
       summary: 'Sti/BSummarySerializer',
     }
   }
-
-  @deco.BelongsTo(['Polymorphic/Chore', 'Polymorphic/Workout'], {
-    polymorphic: true,
-    on: 'taskableId',
-  })
-  public taskable: Chore | Workout
-  public taskableType: DreamColumn<TaskableImage, 'taskableType'>
-  public taskableId: DreamColumn<TaskableImage, 'taskableId'>
 }

--- a/test-app/app/models/Sti/Base.ts
+++ b/test-app/app/models/Sti/Base.ts
@@ -1,7 +1,12 @@
+import Decorators from '../../../../src/decorators/Decorators.js'
 import { DreamColumn, DreamSerializers } from '../../../../src/types/dream.js'
 import ApplicationModel from '../ApplicationModel.js'
+import Pet from '../Pet.js'
+import Chore from '../Polymorphic/Chore.js'
+import TaskableImage from '../Polymorphic/TaskableImage.js'
+import Workout from '../Polymorphic/Workout.js'
 
-// const deco = new Decorators<typeof StiBase>()
+const deco = new Decorators<typeof StiBase>()
 
 export default class StiBase extends ApplicationModel {
   public override get table() {
@@ -20,4 +25,16 @@ export default class StiBase extends ApplicationModel {
   public name: DreamColumn<StiBase, 'name'>
   public createdAt: DreamColumn<StiBase, 'createdAt'>
   public updatedAt: DreamColumn<StiBase, 'updatedAt'>
+
+  @deco.BelongsTo('Pet', { on: 'petId' })
+  public pet: Pet
+  public petId: DreamColumn<StiBase, 'petId'>
+
+  @deco.BelongsTo(['Polymorphic/Chore', 'Polymorphic/Workout'], {
+    polymorphic: true,
+    on: 'taskableId',
+  })
+  public taskable: Chore | Workout
+  public taskableType: DreamColumn<TaskableImage, 'taskableType'>
+  public taskableId: DreamColumn<TaskableImage, 'taskableId'>
 }


### PR DESCRIPTION
## Summary
- validate STI children after association decorators initialize so child-only associations raise StiChildCannotDefineNewAssociations
- move STI test-app associations from child models to the base model
- add a regression spec and bump @rvoh/dream to 2.16.0

## Verification
- pnpm lint
- pnpm build:test-app
- pnpm spec