### PR TITLE
Reject belongs_to on STI child generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 This file provides instructions for AI agents working on this project.
 
+## Starting New Work
+
+Before starting any new work, switch to `main` and pull the latest, unless the
+user explicitly instructs otherwise:
+
+```bash
+git switch main && git pull
+```
+
+We merge pull requests through the GitHub UI, so the local working branch is
+often already merged into `origin/main`. Starting from a stale, already-merged
+branch is the default failure mode this rule prevents.
+
 ## MANDATORY: Completion Gauntlet Before Push / PR
 
 Before pushing a branch, opening a pull request, or otherwise declaring work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.17.2
 
 - The `g:sti-child` CLI help now calls out that `belongs_to` is unsupported for STI children, and the generator rejects `belongs_to` columns before writing files. STI child associations must be declared on the parent model. Plain STI child models also no longer include the commented `Decorators` import/`const deco` scaffold, avoiding boilerplate that points developers toward decorators that are incompatible with STI children.
+- Generated migrations now create an index on generated `deleted_at` columns. This applies to SoftDelete model/resource generation and to generated migrations that add a `deleted_at` column explicitly, so the default `deleted_at IS NULL` SoftDelete scope has a matching database index.
 
 ## 2.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.17.2
+
+- The `g:sti-child` CLI help now calls out that `belongs_to` is unsupported for STI children, and the generator rejects `belongs_to` columns before writing files. STI child associations must be declared on the parent model. Plain STI child models also no longer include the commented `Decorators` import/`const deco` scaffold, avoiding boilerplate that points developers toward decorators that are incompatible with STI children.
+
 ## 2.17.1
 
 - Test database pool setup now treats missing or invalid `parallelTests` configuration as one worker instead of disabled. This means apps that omit `DREAM_PARALLEL_TESTS`, pass `Number(process.env.DREAM_PARALLEL_TESTS)` when the env var is unset, or explicitly set `parallelTests` to `1` still create the minimum per-live-worker database pool during test DB setup. The per-worker claim path already needed that pool even for sequential Vitest runs, because Vitest can start a new process before the previous one has fully exited; Dream now makes the CLI create/drop path and the runtime claim path agree on the same minimum pool width.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"

--- a/spec/unit/cli/DreamBin.spec.ts
+++ b/spec/unit/cli/DreamBin.spec.ts
@@ -246,6 +246,19 @@ describe('DreamBin', () => {
       expect(findWritten('migration')).toBeUndefined()
     })
 
+    it('rejects belongs_to columns before writing files', async () => {
+      await expect(
+        DreamBin.generateStiChild('Room/Kitchen', 'Room', ['User:belongs_to'], {
+          serializer: true,
+          connectionName: 'default',
+        })
+      ).rejects.toThrow(
+        'STI children cannot declare belongs_to associations. Declare associations on the STI parent instead. Unsupported columns: User:belongs_to'
+      )
+
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     context('--admin-serializers flag', () => {
       it('generates admin serializer variants for STI child', async () => {
         await DreamBin.generateStiChild('Room/Kitchen', 'Room', ['oven_count:integer'], {

--- a/spec/unit/cli/DreamCLI.spec.ts
+++ b/spec/unit/cli/DreamCLI.spec.ts
@@ -1,0 +1,13 @@
+import { columnsWithTypesDescriptionForStiChild } from '../../../src/cli/index.js'
+
+describe('DreamCLI', () => {
+  describe('columnsWithTypesDescriptionForStiChild', () => {
+    it('advertises that belongs_to is not supported', () => {
+      expect(columnsWithTypesDescriptionForStiChild).toContain('belongs_to')
+      expect(columnsWithTypesDescriptionForStiChild).toContain('NOT supported for STI children')
+      expect(columnsWithTypesDescriptionForStiChild).toContain('declare all BelongsTo')
+      expect(columnsWithTypesDescriptionForStiChild).toContain('on the STI parent model instead')
+      expect(columnsWithTypesDescriptionForStiChild).not.toContain('User:belongs_to')
+    })
+  })
+})

--- a/spec/unit/cli/generateDreamContent.spec.ts
+++ b/spec/unit/cli/generateDreamContent.spec.ts
@@ -140,10 +140,6 @@ import { STI } from '@rvoh/dream'
 import { DreamColumn, DreamSerializers } from '@rvoh/dream/types'
 import FooBar from '@models/Foo/Bar.js'
 
-// Uncomment when adding decorators (@deco.BelongsTo, @deco.Validates, etc.):
-// import { Decorators } from '@rvoh/dream'
-// const deco = new Decorators<typeof FooBarBaz>()
-
 @STI(FooBar)
 export default class FooBarBaz extends FooBar {
   public override get serializers(): DreamSerializers<FooBarBaz> {
@@ -241,16 +237,27 @@ import { STI } from '@rvoh/dream'
 import { DreamColumn } from '@rvoh/dream/types'
 import Chalupa from '@models/Chalupa.js'
 
-// Uncomment when adding decorators (@deco.BelongsTo, @deco.Validates, etc.):
-// import { Decorators } from '@rvoh/dream'
-// const deco = new Decorators<typeof CrunchyChalupa>()
-
 @STI(Chalupa)
 export default class CrunchyChalupa extends Chalupa {
 
   public deliciousness: DreamColumn<CrunchyChalupa, 'deliciousness'>
 }
 `
+            )
+          })
+
+          it('rejects belongs_to columns', () => {
+            expect(() =>
+              generateDreamContent({
+                fullyQualifiedModelName: 'CrunchyChalupa',
+                modelClassName: modelClassNameFrom('CrunchyChalupa'),
+                fullyQualifiedParentName: 'Chalupa',
+                columnsWithTypes: ['User:belongs_to'],
+                serializer: false,
+                includeAdminSerializers: false,
+              })
+            ).toThrow(
+              'STI children cannot declare belongs_to associations. Declare associations on the STI parent instead. Unsupported columns: User:belongs_to'
             )
           })
         })

--- a/spec/unit/cli/generateMigrationContent.spec.ts
+++ b/spec/unit/cli/generateMigrationContent.spec.ts
@@ -368,6 +368,12 @@ export async function up(db: Kysely<any>): Promise<void> {
     .addColumn('updated_at', 'timestamp', col => col.notNull())
     .addColumn('deleted_at', 'timestamp')
     .execute()
+
+  await db.schema
+    .createIndex('posts_deleted_at')
+    .on('posts')
+    .column('deleted_at')
+    .execute()
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -385,6 +391,7 @@ export async function down(db: Kysely<any>): Promise<void> {
       })
       const matches = res.match(/\.addColumn\('deleted_at'/g) ?? []
       expect(matches).toHaveLength(1)
+      expect(res).toContain("createIndex('posts_deleted_at')")
     })
 
     it('does not duplicate created_at or updated_at when also passed explicitly', () => {
@@ -407,6 +414,7 @@ export async function down(db: Kysely<any>): Promise<void> {
         primaryKeyType: 'bigserial',
       })
       expect(res.match(/\.addColumn\('deleted_at'/g) ?? []).toHaveLength(1)
+      expect(res).toContain("createIndex('posts_deleted_at')")
     })
 
     it('does not duplicate created_at or updated_at when also passed explicitly', () => {
@@ -426,6 +434,42 @@ export async function down(db: Kysely<any>): Promise<void> {
         primaryKeyType: 'bigserial',
       })
       expect(res).not.toContain("addColumn('deleted_at'")
+    })
+  })
+
+  context('deleted_at attributes in alter migrations', () => {
+    it('adds an index for the deleted_at column', () => {
+      const res = generateMigrationContent({
+        table: 'posts',
+        columnsWithTypes: ['deleted_at:datetime:optional'],
+        primaryKeyType: 'bigserial',
+        createOrAlter: 'alter',
+      })
+
+      expect(res).toEqual(`\
+import { Kysely, sql } from 'kysely'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('posts')
+    .addColumn('deleted_at', 'timestamp')
+    .execute()
+
+  await db.schema
+    .createIndex('posts_deleted_at')
+    .on('posts')
+    .column('deleted_at')
+    .execute()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('posts')
+    .dropColumn('deleted_at')
+    .execute()
+}`)
     })
   })
 
@@ -994,8 +1038,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('balloons_type').execute()
-  await db.schema.dropIndex('balloons_user_id').execute()
   await db.schema.dropTable('balloons').execute()
 
   await db.schema.dropType('balloon_types_enum').execute()
@@ -1038,7 +1080,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('balloons_type').execute()
   await db.schema.dropTable('balloons').execute()
 }\
 `
@@ -1077,7 +1118,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `
@@ -1115,7 +1155,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `
@@ -1180,7 +1219,6 @@ export async function down(db: Kysely<any>): Promise<void> {
           )
           expect(res).toContain("createIndex('message_requests_canceled_by_id')")
           expect(res).toContain(".column('canceled_by_id')")
-          expect(res).toContain("dropIndex('message_requests_canceled_by_id')")
         })
 
         it('allows multiple FKs to the same model via distinct aliases', () => {
@@ -1237,7 +1275,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `
@@ -1281,7 +1318,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_user_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `
@@ -1325,7 +1361,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_user_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `
@@ -1369,7 +1404,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_user_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `

--- a/spec/unit/cli/generateOptionalMigrationContent.spec.ts
+++ b/spec/unit/cli/generateOptionalMigrationContent.spec.ts
@@ -265,7 +265,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('balloons_type').execute()
   await db.schema.dropTable('balloons').execute()
 
   await db.schema.dropType('balloon_types_enum').execute()
@@ -306,7 +305,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema.dropTable('compositions').execute()
 }\
 `

--- a/spec/unit/cli/generateStiMigrationContent.spec.ts
+++ b/spec/unit/cli/generateStiMigrationContent.spec.ts
@@ -197,7 +197,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema
     .alterTable('compositions')
     .dropColumn('score_id')
@@ -235,7 +234,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_score_id').execute()
   await db.schema
     .alterTable('compositions')
     .dropColumn('score_id')
@@ -275,7 +273,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.dropIndex('compositions_user_id').execute()
   await db.schema
     .alterTable('compositions')
     .dropColumn('user_id')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,8 +25,8 @@ export type SpawnOptions = Omit<NodeSpawnOptions, 'shell'> & {
 export const CLI_INDENT = '                  '
 const INDENT = CLI_INDENT
 
-export const baseColumnsWithTypesDescription = `space separated snake-case (except for belongs_to model name, which may take an @alias suffix to rename the FK) properties like this:
-${INDENT}    title:citext subtitle:string body_markdown:text style:enum:post_styles:formal,informal User:belongs_to
+export const baseColumnsWithTypesDescription = `space separated snake-case properties like this:
+${INDENT}    title:citext subtitle:string body_markdown:text style:enum:post_styles:formal,informal
 ${INDENT}
 ${INDENT}all properties default to not nullable; null can be allowed by appending ':optional':
 ${INDENT}    subtitle:string:optional
@@ -76,9 +76,12 @@ ${INDENT}          type:enum:room_types or type:enum:room_types:optional
 ${INDENT}
 ${INDENT}        leveraging arrays, add the "[]" suffix, e.g.: type:enum[]:room_types:bathroom,kitchen,bedroom`
 
-const columnsWithTypesDescription =
-  baseColumnsWithTypesDescription +
-  `
+function buildColumnsWithTypesDescription(belongsToDescription: string): string {
+  return `${baseColumnsWithTypesDescription}
+${belongsToDescription}`
+}
+
+const columnsWithTypesDescription = buildColumnsWithTypesDescription(`
 ${INDENT}
 ${INDENT}    - belongs_to:
 ${INDENT}        ALWAYS use this instead of adding a raw uuid column for foreign keys. It creates the FK column, adds a database index,
@@ -96,11 +99,15 @@ ${INDENT}                                                             #   @deco.
 ${INDENT}          Messaging/Template@template:belongs_to             # template_id column, templateId property, template association
 ${INDENT}                                                             #   (strips the namespace from the property/association names while keeping
 ${INDENT}                                                             #   the namespaced model reference intact)
-${INDENT}        Aliasing also lets you declare multiple FKs to the same model in one generator call without column collisions.`
+${INDENT}        Aliasing also lets you declare multiple FKs to the same model in one generator call without column collisions.`)
 
-const columnsWithTypesDescriptionForMigration =
-  baseColumnsWithTypesDescription +
-  `
+export const columnsWithTypesDescriptionForStiChild = buildColumnsWithTypesDescription(`
+${INDENT}
+${INDENT}    - belongs_to:
+${INDENT}        NOT supported for STI children. STI children cannot declare associations; declare all BelongsTo,
+${INDENT}        HasOne, and HasMany associations on the STI parent model instead.`)
+
+const columnsWithTypesDescriptionForMigration = buildColumnsWithTypesDescription(`
 ${INDENT}
 ${INDENT}    - belongs_to:
 ${INDENT}        ALWAYS use this instead of adding a raw uuid column for foreign keys. It creates the FK column with an index.
@@ -113,7 +120,7 @@ ${INDENT}          User:belongs_to:optional          # nullable foreign key
 ${INDENT}
 ${INDENT}        rename the FK column with Model@alias (snake_case alias becomes the column name):
 ${INDENT}          InternalUser@canceled_by:belongs_to:optional       # canceled_by_id column with index
-${INDENT}          Messaging/Template@template:belongs_to             # template_id column (strips the namespace from the column name)`
+${INDENT}          Messaging/Template@template:belongs_to             # template_id column (strips the namespace from the column name)`)
 
 export default class DreamCLI {
   /**
@@ -362,7 +369,7 @@ ${INDENT}  Settings/CommunicationPreferences   # src/app/models/Settings/Communi
       .description(
         `Generates an STI (Single Table Inheritance) child model that extends an existing parent model. The child shares the parent's database table (discriminated by the \`type\` column) and can add child-specific columns. Generates a child model decorated with @STI(Parent), child serializers extending the parent's base serializers, a migration that ALTERs the parent table (not a new table), check constraints, a factory, and spec skeleton.
 ${INDENT}
-${INDENT}If the child declares no additional columns, only the model file is generated — no migration is created. STI children share the parent's table, so a no-columns child requires no schema change. Add a migration only by passing positional field:type args, in which case the generator emits one with the appropriate check constraint. STI children never receive @SoftDelete() — soft delete is enforced at the parent level only — and the generator does not accept --no-soft-delete.
+${INDENT}If the child declares no additional columns, only the model file is generated — no migration is created. STI children share the parent's table, so a no-columns child requires no schema change. Add a migration only by passing positional field:type args, in which case the generator emits one with the appropriate check constraint. STI children cannot declare associations — declare them on the parent model instead. The generator rejects belongs_to columns. STI children never receive @SoftDelete() — soft delete is enforced at the parent level only — and the generator does not accept --no-soft-delete.
 ${INDENT}
 ${INDENT}The parent must already exist (typically generated with g:model --sti-base-serializer or g:resource --sti-base-serializer).
 ${INDENT}
@@ -421,7 +428,7 @@ ${INDENT}Examples:
 ${INDENT}  Room                # extends src/app/models/Room.ts
 ${INDENT}  Health/Coach        # extends src/app/models/Health/Coach.ts`
       )
-      .argument('[columnsWithTypes...]', columnsWithTypesDescription)
+      .argument('[columnsWithTypes...]', columnsWithTypesDescriptionForStiChild)
       .action(
         async (
           childModelName: string,

--- a/src/helpers/cli/generateDreamContent.ts
+++ b/src/helpers/cli/generateDreamContent.ts
@@ -8,6 +8,7 @@ import snakeify from '../snakeify.js'
 import standardizeFullyQualifiedModelName from '../standardizeFullyQualifiedModelName.js'
 import uniq from '../uniq.js'
 import parseAttribute from './parseAttribute.js'
+import validateStiChildColumns from './validateStiChildColumns.js'
 
 interface GenerateDreamContentOptions {
   fullyQualifiedModelName: string
@@ -75,6 +76,8 @@ export interface AttributeProcessingResult {
 
 export default function generateDreamContent(options: GenerateDreamContentOptions): string {
   const config = createModelConfig(options)
+  if (config.isSTI) validateStiChildColumns(options.columnsWithTypes)
+
   // SoftDelete is incompatible with STI children, so it's only applied to
   // non-STI-child models.
   const includeSoftDelete = !config.isSTI && !!options.softDelete
@@ -111,16 +114,20 @@ export default function generateDreamContent(options: GenerateDreamContentOption
   })
 
   const decoBlock = decoratorsInUse
-    ? `const deco = new Decorators<typeof ${config.modelClassName}>()`
-    : `// Uncomment when adding decorators (@deco.BelongsTo, @deco.Validates, etc.):
+    ? `const deco = new Decorators<typeof ${config.modelClassName}>()
+
+`
+    : config.isSTI
+      ? ''
+      : `// Uncomment when adding decorators (@deco.BelongsTo, @deco.Validates, etc.):
 // import { Decorators } from '@rvoh/dream'
-// const deco = new Decorators<typeof ${config.modelClassName}>()`
+// const deco = new Decorators<typeof ${config.modelClassName}>()
+
+`
 
   return `${importSection}
 
-${decoBlock}
-
-${classDeclaration}
+${decoBlock}${classDeclaration}
 ${tableMethod}${serializersMethod}${fieldsSection}
 }
 `.replace(/^\s*$/gm, '')

--- a/src/helpers/cli/generateMigrationContent.ts
+++ b/src/helpers/cli/generateMigrationContent.ts
@@ -11,13 +11,13 @@ import snakeify from '../snakeify.js'
 import standardizeFullyQualifiedModelName from '../standardizeFullyQualifiedModelName.js'
 
 const STI_TYPE_COLUMN_NAME = 'type'
-const COLUMNS_TO_INDEX = [STI_TYPE_COLUMN_NAME]
+const DELETED_AT_COLUMN_NAME = 'deleted_at'
+const COLUMNS_TO_INDEX = [STI_TYPE_COLUMN_NAME, DELETED_AT_COLUMN_NAME]
 
 interface ColumnDefsAndDrops {
   columnDefs: string[]
   columnDrops: string[]
   indexDefs: string[]
-  indexDrops: string[]
 }
 
 export default function generateMigrationContent({
@@ -60,9 +60,9 @@ export default function generateMigrationContent({
       })
   const emitDeletedAtColumn = !altering && (softDelete || userExplicitlyPassedDeletedAt)
 
-  const { columnDefs, columnDrops, indexDefs, indexDrops } = processedColumnsWithTypes.reduce(
+  const { columnDefs, columnDrops, indexDefs } = processedColumnsWithTypes.reduce(
     (acc: ColumnDefsAndDrops, attributeDeclaration: string) => {
-      const { columnDefs, columnDrops, indexDefs, indexDrops } = acc
+      const { columnDefs, columnDrops, indexDefs } = acc
       const [rawSegmentOne, _attributeType, ...descriptors] = attributeDeclaration.split(':')
       if (!rawSegmentOne) return acc
 
@@ -187,15 +187,7 @@ export default function generateMigrationContent({
       columnDrops.push(`.dropColumn('${attributeName}')`)
 
       if (processedAttrType === 'belongsto' || COLUMNS_TO_INDEX.includes(attributeName)) {
-        const indexName = `${table}_${attributeName}`
-
-        indexDefs.push(`await db.schema
-    .createIndex('${indexName}')
-    .on('${table}')
-    .column('${attributeName}')
-    .execute()`)
-
-        indexDrops.push(`await db.schema.dropIndex('${indexName}').execute()`)
+        indexDefs.push(columnIndexStatement(table, attributeName))
       }
 
       if (stiChildClassName && !userWantsThisOptional && !arrayAttribute && !isBooleanColumn) {
@@ -212,8 +204,12 @@ export default function generateMigrationContent({
 
       return acc
     },
-    { columnDefs: [], columnDrops: [], indexDefs: [], indexDrops: [] } as ColumnDefsAndDrops
+    { columnDefs: [], columnDrops: [], indexDefs: [] } as ColumnDefsAndDrops
   )
+
+  if (emitDeletedAtColumn) {
+    indexDefs.push(columnIndexStatement(table, DELETED_AT_COLUMN_NAME))
+  }
 
   if (!table) {
     return `\
@@ -266,7 +262,7 @@ ${citextExtension}${generateEnumStatements(columnsWithTypes)}  await db.schema
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function down(db: Kysely<any>): Promise<void> {
-  ${indexDrops.join(newlineIndent)}${indexDrops.length ? newlineIndent : ''}${
+  ${
     altering
       ? `await db.schema${newlineDoubleIndent}.alterTable('${table}')${columnDropLines}.execute()`
       : `await db.schema.dropTable('${table}').execute()`
@@ -533,6 +529,16 @@ function lookupReferencesTable(
 
 function associationNameToForeignKey(associationName: string) {
   return snakeify(associationName.replace(/\//g, '_').replace(/_id$/, '') + '_id')
+}
+
+function columnIndexStatement(table: string | undefined, attributeName: string) {
+  const indexName = `${table}_${attributeName}`
+
+  return `await db.schema
+    .createIndex('${indexName}')
+    .on('${table}')
+    .column('${attributeName}')
+    .execute()`
 }
 
 export function optionalFromDescriptors(descriptors: string[]): boolean {

--- a/src/helpers/cli/validateStiChildColumns.ts
+++ b/src/helpers/cli/validateStiChildColumns.ts
@@ -1,0 +1,13 @@
+import parseAttribute from './parseAttribute.js'
+
+export default function validateStiChildColumns(columnsWithTypes: string[]) {
+  const belongsToColumns = columnsWithTypes.filter(
+    columnWithType => parseAttribute(columnWithType)?.normalizedAttributeType === 'belongsto'
+  )
+
+  if (belongsToColumns.length) {
+    throw new Error(
+      `STI children cannot declare belongs_to associations. Declare associations on the STI parent instead. Unsupported columns: ${belongsToColumns.join(', ')}`
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- include the AGENTS.md starting-work instructions commit in this branch
- make g:sti-child help state that belongs_to is unsupported for STI children
- reject belongs_to STI child columns before writing files
- stop emitting the commented Decorators import/const deco scaffold for plain STI child models
- bump @rvoh/dream to 2.17.2 and document the CLI behavior change

## Verification
- pnpm lint
- pnpm build:test-app
- pnpm spec