### PR TITLE
Bump package to 2.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.18.1
+
+- No runtime changes. This patch release republishes the 2.18.0 package contents through GitHub Actions after 2.18.0 was accidentally published from a local machine.
+
 ## 2.18.0
 
 Security fixes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "dream orm",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- bump @rvoh/dream from 2.18.0 to 2.18.1
- add a release-only changelog entry for republishing through GitHub Actions

## Verification
- CI=true pnpm lint
- CI=true pnpm build:test-app
- CI=true pnpm spec